### PR TITLE
Fix Poetry install flags in Dockerfiles

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -2,6 +2,8 @@ FROM python:3.10-slim
 
 WORKDIR /app
 COPY pyproject.toml .
-RUN pip install poetry && poetry config virtualenvs.create false && poetry install --no-dev
+RUN pip install poetry && \
+    poetry config virtualenvs.create false && \
+    poetry install --only main
 COPY . .
 CMD ["uvicorn", "stemrunner.server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -3,6 +3,8 @@ FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
 RUN apt-get update && apt-get install -y python3 python3-pip git && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY pyproject.toml .
-RUN pip3 install poetry && poetry config virtualenvs.create false && poetry install --no-dev
+RUN pip3 install poetry && \
+    poetry config virtualenvs.create false && \
+    poetry install --only main
 COPY . .
 CMD ["uvicorn", "stemrunner.server:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- fix Docker build step by using `poetry install --only main`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686793b214f08328b1eafae78a0c3911