### PR TITLE
Add browser-based installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,19 @@ Metal (MPS).
 
 ## Installing dependencies
 
+The repository includes an interactive installer that sets up a virtual
+environment and installs the Python packages while showing a progress bar in
+your browser. Run it with:
+
 ```bash
-./setup.sh
+python install.py
 ```
 
-Or do it manually:
+Your default browser will open `http://localhost:6060` where a loading bar
+displays each installation step. When the bar reaches 100% the environment is
+ready to use. If a step fails an error message appears on the page.
+
+You can still perform the steps manually if you prefer:
 
 ```bash
 python -m venv venv

--- a/install.py
+++ b/install.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import http.server
+import socketserver
+import threading
+import subprocess
+import sys
+import os
+import json
+import webbrowser
+from pathlib import Path
+
+progress = {"pct": 0, "step": "starting"}
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/progress':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(progress).encode())
+        else:
+            if self.path == '/' or self.path == '/index.html':
+                html_path = Path(__file__).resolve().parent / 'web' / 'install.html
+                html = html_path.read_text()
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/html')
+                self.end_headers()
+                self.wfile.write(html.encode())
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+def run_server():
+    with socketserver.TCPServer(('localhost', 6060), Handler) as httpd:
+        webbrowser.open('http://localhost:6060/')
+        httpd.serve_forever()
+
+def pip_path():
+    if os.name == 'nt':
+        return Path('venv') / 'Scripts' / 'pip'
+    else:
+        return Path('venv') / 'bin' / 'pip'
+
+def install():
+    steps = [
+        ('creating virtual environment', [sys.executable, '-m', 'venv', 'venv']),
+        ('upgrading pip', [str(pip_path()), 'install', '--upgrade', 'pip']),
+        ('installing requirements', [str(pip_path()), 'install', '-r', 'requirements.txt'])
+    ]
+    total = len(steps)
+    for i, (msg, cmd) in enumerate(steps, start=1):
+        progress['step'] = msg
+        progress['pct'] = int((i-1)/total*100)
+        try:
+            subprocess.check_call(cmd)
+        except subprocess.CalledProcessError:
+            progress['step'] = f'error during {msg}'
+            progress['pct'] = -1
+            return
+    progress['pct'] = 100
+    progress['step'] = 'done'
+
+if __name__ == '__main__':
+    server_thread = threading.Thread(target=run_server, daemon=True)
+    server_thread.start()
+    install()

--- a/web/install.html
+++ b/web/install.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>stemsplat setup</title>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      --bg-deep: #0f0f11;
+      --bg-card: rgba(40,40,48,0.55);
+      --txt-main: #e5e5e5;
+      --accent: #2ec7f8;
+      --accent-lite: #47d6ff;
+    }
+    .glass {
+      background: var(--bg-card);
+      backdrop-filter: blur(18px) saturate(120%);
+      -webkit-backdrop-filter: blur(18px) saturate(120%);
+      border: 1px solid rgba(255,255,255,0.08);
+    }
+    .fade-in {
+      animation: fade 0.7s ease forwards;
+    }
+    @keyframes fade {
+      from { opacity: 0; transform: translateY(12px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+  </style>
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center gap-10" style="background: var(--bg-deep); font-family: 'Nunito Sans', sans-serif;">
+  <h1 class="text-4xl font-light text-[var(--txt-main)] fade-in select-none">stemsplat setup</h1>
+  <div class="glass w-11/12 max-w-xl px-8 py-6 rounded-xl flex flex-col gap-4 fade-in">
+    <span id="status" class="text-[var(--txt-main)]">starting…</span>
+    <div class="w-full h-3 bg-gray-700 rounded overflow-hidden">
+      <div id="bar" class="h-full bg-[var(--accent)]" style="width:0%"></div>
+    </div>
+    <div id="error" class="hidden text-red-400 text-sm"></div>
+  </div>
+  <script>
+    async function poll(){
+      const res = await fetch('/progress');
+      const data = await res.json();
+      const bar = document.getElementById('bar');
+      const status = document.getElementById('status');
+      const err = document.getElementById('error');
+      if(data.pct >= 0){ bar.style.width = data.pct + '%'; }
+      status.textContent = data.step;
+      if(data.pct === -1){ err.textContent = 'installation failed'; err.classList.remove('hidden'); return; }
+      if(data.pct >= 100){ return; }
+      setTimeout(poll, 1000);
+    }
+    poll();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `install.py` which runs an HTTP server and executes setup steps
- show installation progress in `web/install.html`
- document new installer in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68685f7330f8832882ec71ef828fe965