### PR TITLE
Enable basic processing and downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ python install.py
 Your default browser will open `http://localhost:6060` where a loading bar
 displays each installation step. When the bar reaches 100% the environment is
 ready to use. If a step fails an error message appears on the page.
+The server automatically starts at http://localhost:8000 when installation completes.
 
 You can still perform the steps manually if you prefer:
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ instrumental, drums, bass, other, karaoke and guitar).
 - Check CUDA drivers if GPU inference fails.
 - Ensure checkpoint files are present in `models/`.
 - Verify `.yaml` configs are in `configs/`.
+- Ensure model filenames match those listed in `stemrunner/models.py`.
 - Install `ffmpeg` if uploads fail to convert or load.
 - Ensure Python packages installed correctly; reinstall requirements if the
   server complains about missing modules like `numpy`.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ instrumental, drums, bass, other, karaoke and guitar).
 - Ensure checkpoint files are present in `models/`.
 - Verify `.yaml` configs are in `configs/`.
 - Install `ffmpeg` if uploads fail to convert or load.
+- Ensure Python packages installed correctly; reinstall requirements if the
+  server complains about missing modules like `numpy`.
 
 
 ## Double-click installer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ fastapi = "*"
 uvicorn = {extras = ["standard"], version = "*"}
 click = "*"
 sse-starlette = "*"
+numpy = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ uvicorn[standard]
 click
 sse-starlette
 python-multipart
+numpy

--- a/stemrunner/models.py
+++ b/stemrunner/models.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Optional
 import torch
+import torchaudio
 
 def _select_device(gpu: Optional[int]) -> torch.device:
     """Return best available device. Prefers CUDA when gpu provided,
@@ -58,16 +59,16 @@ class ModelManager:
         return None
 
     def split_vocals(self, waveform, segment: int, overlap: int):
-        # Placeholder: implement real inference here
-        vocals = waveform.clone()
-        instrumental = waveform.clone()
+        sr = 44100
+        vocals = torch.clone(torchaudio.functional.highpass_biquad(waveform, sr, 1000))
+        instrumental = waveform - vocals
         return vocals, instrumental
 
     def split_instrumental(self, waveform, segment: int, overlap: int):
-        """Placeholder secondary split producing five stems."""
-        drums = waveform.clone()
-        bass = waveform.clone()
-        other = waveform.clone()
+        sr = 44100
+        drums = torchaudio.functional.highpass_biquad(waveform, sr, 1500)
+        bass = torchaudio.functional.lowpass_biquad(waveform, sr, 250)
+        other = waveform - drums - bass
         karaoke = waveform.clone()
-        guitar = waveform.clone()
+        guitar = torchaudio.functional.bandpass_biquad(waveform, sr, 600, 0.707)
         return drums, bass, other, karaoke, guitar

--- a/stemrunner/pipeline.py
+++ b/stemrunner/pipeline.py
@@ -10,8 +10,8 @@ import torchaudio
 from .models import ModelManager
 
 SEGMENT_STAGE_A = 352800
-SEGMENT_STAGE_B = 4000
-OVERLAP = 8
+SEGMENT_STAGE_B = SEGMENT_STAGE_A
+OVERLAP = 12
 
 
 def _convert_to_wav(path: Path, sample_rate: int) -> Path:

--- a/stemrunner/pipeline.py
+++ b/stemrunner/pipeline.py
@@ -123,7 +123,7 @@ def process_file(
     segment: int | None = None,
     outdir: str | None = None,
     progress_cb: Optional[Callable[[str, int], None]] = None,
-    delay: float = 0.0,
+    delay: float = 0.5,
 ):
     """Process a single audio file and save stems."""
     if progress_cb is None:

--- a/stemrunner/server.py
+++ b/stemrunner/server.py
@@ -37,7 +37,7 @@ async def upload_file(background_tasks: BackgroundTasks, file: UploadFile = File
 
     def run():
         try:
-            process_file(path, manager, progress_cb=cb, delay=0.1)
+            process_file(path, manager, progress_cb=cb, delay=0.5)
         except Exception as exc:
             logging.exception('processing failed')
             progress[task_id] = {'stage': 'error', 'pct': -1}

--- a/stemrunner/server.py
+++ b/stemrunner/server.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, UploadFile, File, BackgroundTasks, HTTPException
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from sse_starlette.sse import EventSourceResponse
 from pathlib import Path
 import uuid
@@ -13,6 +13,7 @@ app = FastAPI()
 manager = ModelManager()
 progress = {}
 errors = {}
+tasks = {}
 
 
 @app.post('/upload')
@@ -43,6 +44,8 @@ async def upload_file(background_tasks: BackgroundTasks, file: UploadFile = File
     progress[task_id] = 0
     stems = [f"{Path(file.filename).stem}—{name}.wav" for name in [
         'Vocals', 'Instrumental', 'Drums', 'Bass', 'Other', 'Karaoke', 'Guitar']]
+    out_dir = Path('uploads') / f"{Path(file.filename).stem}—stems"
+    tasks[task_id] = {'dir': out_dir, 'stems': stems}
     return {'task_id': task_id, 'stems': stems}
 
 
@@ -62,6 +65,26 @@ async def progress_stream(task_id: str):
                 break
             await asyncio.sleep(0.5)
     return EventSourceResponse(event_generator())
+
+
+@app.get('/download/{task_id}')
+async def download(task_id: str):
+    info = tasks.get(task_id)
+    if not info:
+        raise HTTPException(status_code=404, detail='invalid task id')
+    if not info['dir'].exists():
+        raise HTTPException(status_code=404, detail='files not ready')
+    import io, zipfile
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        for name in info['stems']:
+            fp = info['dir'] / name
+            if fp.exists():
+                zf.write(fp, arcname=name)
+    buf.seek(0)
+    return StreamingResponse(buf, media_type='application/zip', headers={
+        'Content-Disposition': f'attachment; filename="{info["dir"].name}.zip"'
+    })
 
 
 @app.get('/', response_class=HTMLResponse)

--- a/stemrunner/server.py
+++ b/stemrunner/server.py
@@ -37,7 +37,7 @@ async def upload_file(background_tasks: BackgroundTasks, file: UploadFile = File
 
     def run():
         try:
-            process_file(path, manager, progress_cb=cb)
+            process_file(path, manager, progress_cb=cb, delay=0.1)
         except Exception as exc:
             logging.exception('processing failed')
             progress[task_id] = {'stage': 'error', 'pct': -1}

--- a/web/index.html
+++ b/web/index.html
@@ -78,7 +78,7 @@
         <span class="truncate text-[var(--txt-main)] text-sm filename"></span>
         <div class="flex items-center gap-3">
           <span class="text-xs text-[var(--accent-lite)] status">queued</span>
-          <a class="download hidden text-xs underline text-[var(--accent-lite)]" href="#">download</a>
+          <a class="download hidden px-3 py-1 rounded bg-[var(--accent-lite)] text-black text-xs" href="#">download</a>
         </div>
       </div>
       <div class="w-full h-2 bg-gray-700 rounded overflow-hidden">

--- a/web/index.html
+++ b/web/index.html
@@ -223,8 +223,8 @@
 
     function trackProgress(id, bar, st, dl, task){
       const es = new EventSource(`/progress/${id}`);
-      es.onmessage = (e) => {
-        const info = JSON.parse(e.data);
+      es.onmessage = (evt) => {
+        const info = JSON.parse(evt.data);
         bar.style.width = info.pct + '%';
         const [s,e] = STAGE_RANGES[info.stage] || [0,100];
         const sp = Math.round(((info.pct - s) / (e - s)) * 100);

--- a/web/index.html
+++ b/web/index.html
@@ -76,7 +76,10 @@
     <div class="glass rounded-xl px-6 py-4 flex flex-col gap-2">
       <div class="flex justify-between items-center">
         <span class="truncate text-[var(--txt-main)] text-sm filename"></span>
-        <span class="text-xs text-[var(--accent-lite)] status">queued</span>
+        <div class="flex items-center gap-3">
+          <span class="text-xs text-[var(--accent-lite)] status">queued</span>
+          <a class="download hidden text-xs underline text-[var(--accent-lite)]" href="#">download</a>
+        </div>
       </div>
       <div class="w-full h-2 bg-gray-700 rounded overflow-hidden">
         <div class="h-full bg-[var(--accent)] progress" style="width:0%"></div>
@@ -104,13 +107,14 @@
       const li   = node.querySelector('.filename');
       const bar  = node.querySelector('.progress');
       const st   = node.querySelector('.status');
+      const dl   = node.querySelector('.download');
       li.textContent = task.name;
       bar.style.width = (task.pct||0) + '%';
-      if(task.pct >= 100) st.textContent = 'done';
+      if(task.pct >= 100){ st.textContent = 'done'; dl.classList.remove('hidden'); dl.href = '/download/' + task.id; }
       else if(task.pct < 0) st.textContent = 'error';
       else st.textContent = task.pct ? ('processing ' + task.pct + '%') : 'queued';
       queue.appendChild(node);
-      return {bar, st};
+      return {bar, st, dl};
     }
 
     clearBtn.addEventListener('click', () => {
@@ -122,9 +126,9 @@
 
     // restore previous tasks
     tasks.forEach(t => {
-      const {bar, st} = createItem(t);
+      const {bar, st, dl} = createItem(t);
       if(t.pct < 100 && t.pct >= 0){
-        trackProgress(t.id, bar, st, t);
+        trackProgress(t.id, bar, st, dl, t);
       }
     });
     updateClear();
@@ -195,11 +199,11 @@
           }
           const res = JSON.parse(xhr.responseText);
           st.textContent = 'processing…';
-          const task = {id: res.task_id, name: file.name, pct: 0};
+          const task = {id: res.task_id, name: file.name, pct: 0, stems: res.stems};
           tasks.push(task);
           saveTasks();
           updateClear();
-          trackProgress(res.task_id, bar, st, task);
+          trackProgress(res.task_id, bar, st, node.querySelector('.download'), task);
         };
         xhr.onerror = () => {
           st.textContent = 'error';
@@ -210,7 +214,7 @@
       });
     }
 
-    function trackProgress(id, bar, st, task){
+    function trackProgress(id, bar, st, dl, task){
       const es = new EventSource(`/progress/${id}`);
       es.onmessage = (e) => {
         const pct = parseInt(e.data);
@@ -218,7 +222,7 @@
         st.textContent  = 'processing ' + pct + '%';
         task.pct = pct;
         saveTasks();
-        if(pct >= 100){ es.close(); st.textContent = 'done'; saveTasks(); }
+        if(pct >= 100){ es.close(); st.textContent = 'done'; dl.classList.remove('hidden'); dl.href = '/download/' + id; saveTasks(); }
         if(pct < 0){ es.close(); st.textContent = 'error'; showError('processing failed'); saveTasks(); }
       };
       es.addEventListener('error', (e) => {

--- a/web/index.html
+++ b/web/index.html
@@ -96,6 +96,7 @@
     const template  = document.getElementById('item-template');
 
     let tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+    const STAGE_RANGES = {preparing:[0,10], vocals:[10,50], stems:[50,100], done:[100,100]};
     function saveTasks(){ localStorage.setItem('tasks', JSON.stringify(tasks)); }
     function updateClear(){
       if(tasks.length) clearBtn.classList.remove('hidden');
@@ -112,7 +113,11 @@
       bar.style.width = (task.pct||0) + '%';
       if(task.pct >= 100){ st.textContent = 'done'; dl.classList.remove('hidden'); dl.href = '/download/' + task.id; }
       else if(task.pct < 0) st.textContent = 'error';
-      else st.textContent = task.stage ? `${task.stage} (${task.pct}%)` : 'queued';
+      else {
+        const [s,e] = STAGE_RANGES[task.stage] || [0,100];
+        const sp = Math.round(((task.pct - s) / (e - s)) * 100);
+        st.textContent = task.stage ? `${task.stage} (${sp}%)` : 'queued';
+      }
       queue.appendChild(node);
       return {bar, st, dl};
     }
@@ -221,7 +226,9 @@
       es.onmessage = (e) => {
         const info = JSON.parse(e.data);
         bar.style.width = info.pct + '%';
-        st.textContent  = info.stage ? `${info.stage} (${info.pct}%)` : `${info.pct}%`;
+        const [s,e] = STAGE_RANGES[info.stage] || [0,100];
+        const sp = Math.round(((info.pct - s) / (e - s)) * 100);
+        st.textContent  = info.stage ? `${info.stage} (${sp}%)` : `${info.pct}%`;
         task.pct = info.pct;
         task.stage = info.stage;
         saveTasks();

--- a/web/index.html
+++ b/web/index.html
@@ -112,7 +112,7 @@
       bar.style.width = (task.pct||0) + '%';
       if(task.pct >= 100){ st.textContent = 'done'; dl.classList.remove('hidden'); dl.href = '/download/' + task.id; }
       else if(task.pct < 0) st.textContent = 'error';
-      else st.textContent = task.pct ? ('processing ' + task.pct + '%') : 'queued';
+      else st.textContent = task.stage ? `${task.stage} (${task.pct}%)` : 'queued';
       queue.appendChild(node);
       return {bar, st, dl};
     }
@@ -156,7 +156,9 @@
       alert('Upload failed: ' + msg + '\n\nTroubleshooting steps:\n' +
             '1. Make sure the server is running.\n' +
             '2. Verify you selected a valid audio file.\n' +
-            '3. Check the terminal for additional details.');
+            '3. Check that required model files are downloaded.\n' +
+            '4. Try processing a shorter clip.\n' +
+            '5. Check the terminal for additional details.');
     }
 
     /* === upload & progress logic === */
@@ -198,8 +200,8 @@
             return;
           }
           const res = JSON.parse(xhr.responseText);
-          st.textContent = 'processing…';
-          const task = {id: res.task_id, name: file.name, pct: 0, stems: res.stems};
+          st.textContent = 'preparing (0%)';
+          const task = {id: res.task_id, name: file.name, pct: 0, stage: 'preparing', stems: res.stems};
           tasks.push(task);
           saveTasks();
           updateClear();
@@ -217,13 +219,14 @@
     function trackProgress(id, bar, st, dl, task){
       const es = new EventSource(`/progress/${id}`);
       es.onmessage = (e) => {
-        const pct = parseInt(e.data);
-        bar.style.width = pct + '%';
-        st.textContent  = 'processing ' + pct + '%';
-        task.pct = pct;
+        const info = JSON.parse(e.data);
+        bar.style.width = info.pct + '%';
+        st.textContent  = info.stage ? `${info.stage} (${info.pct}%)` : `${info.pct}%`;
+        task.pct = info.pct;
+        task.stage = info.stage;
         saveTasks();
-        if(pct >= 100){ es.close(); st.textContent = 'done'; dl.classList.remove('hidden'); dl.href = '/download/' + id; saveTasks(); }
-        if(pct < 0){ es.close(); st.textContent = 'error'; showError('processing failed'); saveTasks(); }
+        if(info.pct >= 100){ es.close(); st.textContent = 'done'; dl.classList.remove('hidden'); dl.href = '/download/' + id; saveTasks(); }
+        if(info.pct < 0){ es.close(); st.textContent = 'error'; showError('processing failed'); saveTasks(); }
       };
       es.addEventListener('error', (e) => {
         es.close();


### PR DESCRIPTION
## Summary
- implement crude splitting logic with torchaudio filters
- keep track of processed tasks and provide `/download/{task_id}`
- expose a download button next to finished items in the web UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868e215c40483289eb220e21fe1ed03