### PR TITLE
Implement smoother UI and sequential processing

### DIFF
--- a/stemrunner/pipeline.py
+++ b/stemrunner/pipeline.py
@@ -65,8 +65,8 @@ def process_file(
     ]
 
     def _cb(frac: float) -> None:
-        # Map 0‑100 into the “vocals” stage range (10‑100)
-        progress_cb("vocals", 10 + int(frac * 90))
+        # Map 0‑100 into the “vocals” stage range (1‑100)
+        progress_cb("vocals", 1 + int(frac * 99))
 
     progress_cb("preparing", 0)
     split_main(args, progress_cb=_cb)

--- a/web/index.html
+++ b/web/index.html
@@ -36,6 +36,14 @@
       from { opacity: 0; transform: translateY(12px); }
       to   { opacity: 1; transform: translateY(0); }
     }
+    #top-vig, #bot-vig {
+      pointer-events:none; position:fixed; left:0; right:0; height:40px;
+      background:linear-gradient(to bottom,var(--bg-deep),transparent);
+      opacity:0; transition:opacity 0.3s;
+    }
+    #bot-vig{
+      top:auto; bottom:0; transform:rotate(180deg);
+    }
   </style>
 </head>
 
@@ -49,7 +57,8 @@
   </div>
 
   <!-- header -->
-  <h1 class="text-4xl font-light text-[var(--txt-main)] fade-in select-none">stemsplat</h1>  <!-- controls -->
+  <h1 id="title" class="text-4xl font-light text-[var(--txt-main)] select-none opacity-0">stemsplat</h1>
+  <!-- controls -->
   <div class="w-11/12 max-w-3xl flex gap-6">
     <div id="dropzone" class="glass flex-1 px-10 py-14 rounded-3xl text-center fade-in flex flex-col items-center gap-6 cursor-pointer transition-transform duration-200 hover:scale-105">
       <svg xmlns="http://www.w3.org/2000/svg" class="w-14 h-14 stroke-[var(--accent)]" fill="none" viewBox="0 0 24 24" stroke-width="1.5">
@@ -71,6 +80,9 @@
   <!-- queue -->
   <div id="queue" class="w-11/12 max-w-2xl flex flex-col gap-4"></div>
   <button id="clear-btn" class="mt-4 text-white underline hidden">clear all</button>
+  <button id="top-btn" class="hidden fixed top-4 right-4 bg-white text-black rounded px-3 py-1">top</button>
+  <div id="top-vig"></div>
+  <div id="bot-vig"></div>
 
   <!-- templates & scripts -->
   <template id="item-template">
@@ -78,6 +90,12 @@
       <div class="flex justify-between items-center">
         <span class="truncate text-[var(--txt-main)] text-sm filename"></span>
         <div class="flex items-center gap-3">
+          <button class="pause hidden w-6 h-6 bg-white rounded flex items-center justify-center">
+            <svg class="w-3 h-3 text-gray-800" viewBox="0 0 24 24" fill="currentColor"><path d="M5 4h4v16H5zm10 0h4v16h-4z"/></svg>
+          </button>
+          <button class="stop hidden w-6 h-6 bg-white rounded flex items-center justify-center">
+            <svg class="w-3 h-3 text-gray-800" viewBox="0 0 24 24" fill="currentColor"><path d="M5 5h14v14H5z"/></svg>
+          </button>
           <span class="text-xs text-[var(--accent-lite)] status">queued</span>
           <a class="download hidden px-3 py-1 rounded bg-[var(--accent-lite)] text-black text-xs" href="#">download</a>
         </div>
@@ -95,14 +113,67 @@
     const vocalsBox = document.getElementById('vocals-box');
     const queue     = document.getElementById('queue');
     const clearBtn  = document.getElementById('clear-btn');
+    const topBtn    = document.getElementById('top-btn');
+    const topVig    = document.getElementById('top-vig');
+    const botVig    = document.getElementById('bot-vig');
     const template  = document.getElementById('item-template');
+    const title     = document.getElementById('title');
+
+    if(localStorage.getItem('playIntro')){
+      localStorage.removeItem('playIntro');
+      title.style.position = 'absolute';
+      title.style.left = '50%';
+      title.style.top = '45%';
+      title.style.transform = 'translate(-50%, -50%)';
+      title.style.opacity = '1';
+      setTimeout(() => {
+        title.style.transition = 'all 0.5s ease';
+        title.style.left = '';
+        title.style.top = '';
+        title.style.transform = '';
+      }, 50);
+      setTimeout(() => {
+        document.querySelectorAll('#dropzone, .glass.w-64, #queue, #clear-btn').forEach((el,i)=>{
+          setTimeout(()=>{el.classList.add('fade-in')}, i*25);
+        });
+      }, 600);
+    } else {
+      title.classList.add('fade-in');
+    }
 
     let tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
-    const STAGE_RANGES = {preparing:[0,10], vocals:[10,100], done:[100,100]};
+    const STAGE_RANGES = {preparing:[0,1], vocals:[1,100], done:[100,100]};
     function saveTasks(){ localStorage.setItem('tasks', JSON.stringify(tasks)); }
     function updateClear(){
       if(tasks.length) clearBtn.classList.remove('hidden');
       else clearBtn.classList.add('hidden');
+    }
+    function updateVigs(){
+      const rect = queue.getBoundingClientRect();
+      topVig.style.opacity = window.scrollY > 0 ? '1' : '0';
+      botVig.style.opacity = rect.bottom > window.innerHeight ? '1' : '0';
+      if(rect.bottom > window.innerHeight) topBtn.classList.remove('hidden');
+      else topBtn.classList.add('hidden');
+    }
+    function updateUI(){
+      updateClear();
+      updateVigs();
+    }
+
+    function setupControls(pauseBtn, stopBtn, id){
+      const icon = pauseBtn.querySelector('path');
+      pauseBtn.onclick = () => {
+        if(pauseBtn.dataset.state === 'paused'){
+          fetch('/resume/' + id, {method:'POST'});
+          pauseBtn.dataset.state = 'running';
+          icon.setAttribute('d','M5 4h4v16H5zm10 0h4v16h-4z');
+        } else {
+          fetch('/pause/' + id, {method:'POST'});
+          pauseBtn.dataset.state = 'paused';
+          icon.setAttribute('d','M6 4l12 8-12 8z');
+        }
+      };
+      stopBtn.onclick = () => { fetch('/stop/' + id, {method:'POST'}); };
     }
 
     function createItem(task){
@@ -111,38 +182,49 @@
       const bar  = node.querySelector('.progress');
       const st   = node.querySelector('.status');
       const dl   = node.querySelector('.download');
+      const pause= node.querySelector('.pause');
+      const stop = node.querySelector('.stop');
       li.textContent = task.name;
       bar.style.width = (task.pct||0) + '%';
       if(task.pct >= 100){
         st.classList.add('hidden');
         dl.classList.remove('hidden');
         dl.href = '/download/' + task.id;
+        pause.remove();
+        stop.remove();
       }
       else if(task.pct < 0) st.textContent = 'error';
       else {
         const [s,e] = STAGE_RANGES[task.stage] || [0,100];
         const sp = Math.round(((task.pct - s) / (e - s)) * 100);
         st.textContent = task.stage ? `${task.stage} (${sp}%)` : 'queued';
+        pause.classList.remove('hidden');
+        stop.classList.remove('hidden');
+        setupControls(pause, stop, task.id);
       }
       queue.appendChild(node);
-      return {bar, st, dl};
+      updateVigs();
+      return {bar, st, dl, pause, stop};
     }
 
     clearBtn.addEventListener('click', () => {
+      window.scrollTo({top:0, behavior:'smooth'});
       queue.innerHTML = '';
       tasks = [];
       saveTasks();
-      updateClear();
+      updateUI();
     });
 
     // restore previous tasks
     tasks.forEach(t => {
-      const {bar, st, dl} = createItem(t);
+      const {bar, st, dl, pause, stop} = createItem(t);
       if(t.pct < 100 && t.pct >= 0){
-        trackProgress(t.id, bar, st, dl, t);
+        trackProgress(t.id, bar, st, dl, pause, stop, t);
       }
     });
-    updateClear();
+    updateUI();
+    window.addEventListener('scroll', updateVigs);
+    topBtn.addEventListener('click', () => window.scrollTo({top:0, behavior:'smooth'}));
 
     // drag-and-drop highlights
     ['dragenter','dragover'].forEach(evt =>
@@ -168,7 +250,10 @@
       overlay.className = 'fixed inset-0 flex items-center justify-center backdrop-blur-sm';
       overlay.innerHTML = `<div class="glass p-6 rounded-xl flex flex-col gap-4 text-[var(--txt-main)]"><p class="text-center">Upload failed: ${msg}</p><button class="mx-auto px-4 py-1 bg-[var(--accent)] rounded text-black">ok</button></div>`;
       document.body.appendChild(overlay);
-      overlay.querySelector('button').onclick = () => overlay.remove();
+      const btn = overlay.querySelector('button');
+      btn.onclick = () => overlay.remove();
+      overlay.tabIndex = 0; overlay.focus();
+      overlay.addEventListener('keydown', e => { if(e.key === 'Enter') btn.click(); });
     }
 
     function showPopup(msg){
@@ -187,8 +272,12 @@
       overlay.className = 'fixed inset-0 flex items-center justify-center backdrop-blur-sm';
       overlay.innerHTML = `<div class="glass p-6 rounded-xl flex flex-col gap-2 text-[var(--txt-main)]"><p>${msg}</p><div class="flex justify-end gap-2"><button id="no-btn" class="px-3 py-1 bg-gray-500 rounded">nah i still got it</button><button id="yes-btn" class="px-3 py-1 bg-[var(--accent)] rounded text-black">${yes}</button></div></div>`;
       document.body.appendChild(overlay);
-      overlay.querySelector('#no-btn').onclick = () => { localStorage.setItem('declinedModels','1'); overlay.remove(); if(onCancel) onCancel(); updateClear(); };
-      overlay.querySelector('#yes-btn').onclick = () => { localStorage.removeItem('declinedModels'); fetch('/download_models', {method:'POST'}); overlay.remove(); };
+      const noBtn = overlay.querySelector('#no-btn');
+      const yesBtn = overlay.querySelector('#yes-btn');
+      noBtn.onclick = () => { localStorage.setItem('declinedModels','1'); overlay.remove(); if(onCancel) onCancel(); updateUI(); };
+      yesBtn.onclick = () => { localStorage.removeItem('declinedModels'); fetch('/download_models', {method:'POST'}); overlay.remove(); };
+      overlay.tabIndex = 0; overlay.focus();
+      overlay.addEventListener('keydown', e => { if(e.key === 'Enter') yesBtn.click(); });
     }
 
     /* === upload & progress logic === */
@@ -207,8 +296,11 @@
         const li   = item.querySelector('.filename');
         const bar  = item.querySelector('.progress');
         const st   = item.querySelector('.status');
+        const pause= item.querySelector('.pause');
+        const stop = item.querySelector('.stop');
         li.textContent = file.name;
         queue.appendChild(item);
+        updateVigs();
 
         // prepare form data
         const data = new FormData();
@@ -233,7 +325,7 @@
             try { msg = JSON.parse(xhr.responseText).detail || msg; } catch(e) {}
             if(msg.includes('checkpoint not found')) showModelsPopup(() => item.remove());
             else showError(msg);
-            updateClear();
+            updateUI();
             return;
           }
           const res = JSON.parse(xhr.responseText);
@@ -241,20 +333,22 @@
           const task = {id: res.task_id, name: file.name, pct: 0, stage: 'preparing', stems: res.stems};
           tasks.push(task);
           saveTasks();
-          updateClear();
-          trackProgress(res.task_id, bar, st, item.querySelector('.download'), task);
+          updateUI();
+          setupControls(pause, stop, res.task_id);
+          const dl = item.querySelector('.download');
+          trackProgress(res.task_id, bar, st, dl, pause, stop, task);
         };
         xhr.onerror = () => {
           st.textContent = 'error';
           showError('network error during upload');
-          updateClear();
+          updateUI();
         };
 
         xhr.send(data);
       });
     }
 
-    function trackProgress(id, bar, st, dl, task){
+    function trackProgress(id, bar, st, dl, pause, stop, task){
       const es = new EventSource(`/progress/${id}`);
       es.onmessage = (evt) => {
         const info = JSON.parse(evt.data);
@@ -262,6 +356,13 @@
         const [s,e] = STAGE_RANGES[info.stage] || [0,100];
         const sp = Math.round(((info.pct - s) / (e - s)) * 100);
         st.textContent  = info.stage ? `${info.stage} (${sp}%)` : `${info.pct}%`;
+        if(info.stage === 'paused'){
+          pause.dataset.state = 'paused';
+          pause.querySelector('path').setAttribute('d','M6 4l12 8-12 8z');
+        } else if(pause.dataset.state === 'paused'){
+          pause.dataset.state = 'running';
+          pause.querySelector('path').setAttribute('d','M5 4h4v16H5zm10 0h4v16h-4z');
+        }
         task.pct = info.pct;
         task.stage = info.stage;
         saveTasks();
@@ -270,6 +371,8 @@
           st.classList.add('hidden');
           dl.classList.remove('hidden');
           dl.href = '/download/' + id;
+          pause.remove();
+          stop.remove();
           saveTasks();
         }
         if(info.pct < 0){ es.close(); st.textContent = 'error'; showError('processing failed'); saveTasks(); }

--- a/web/launch.html
+++ b/web/launch.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>stemsplat</title>
+  <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      --bg-deep: #0f0f11;
+      --txt-main: #e5e5e5;
+    }
+  </style>
+</head>
+<body class="min-h-screen flex flex-col items-center justify-center gap-6" style="background:var(--bg-deep); font-family:'Nunito Sans', sans-serif;">
+  <h1 class="text-4xl font-light text-[var(--txt-main)] select-none">stemsplat</h1>
+  <div class="text-[var(--txt-main)]">starting server…</div>
+  <script>
+    async function wait(){
+      while(true){
+        try{ await fetch('http://localhost:8000/', {mode:'no-cors'}); location.href='http://localhost:8000/'; return; }catch(e){}
+        await new Promise(r=>setTimeout(r,1000));
+      }
+    }
+    localStorage.setItem('playIntro','1');
+    wait();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a launch page for subsequent runs
- animate header intro and add smooth scrolling helpers
- tweak progress ranges and show keyboard handling for dialogs
- queue song processing sequentially and rename stems
- update install script for launch-only mode
- add pause/resume/stop controls and verify required files exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ac136d3c08328bac9dc2b201285cf