### PR TITLE
Improve model checks on upload

### DIFF
--- a/stemrunner/models.py
+++ b/stemrunner/models.py
@@ -107,14 +107,14 @@ class ModelManager:
                 setattr(self, f"{name}_config", self._load_path(CONFIGS_DIR / cfg_fname))
 
     def missing_models(self):
-        """Return a list of model or config files that could not be found."""
+        """Return model or config files that are unavailable or unusable."""
         self.refresh_models()
         missing = []
         for name, (model_fname, cfg_fname) in self.model_info.items():
             model_obj = getattr(self, name)
-            if model_obj.kind == 'none':
+            if model_obj.kind not in ('onnx', 'torchscript'):
                 missing.append(model_fname)
-            elif cfg_fname and getattr(self, f"{name}_config") is None:
+            if cfg_fname and getattr(self, f"{name}_config") is None:
                 missing.append(cfg_fname)
         return missing
 

--- a/stemrunner/models.py
+++ b/stemrunner/models.py
@@ -38,7 +38,11 @@ class StemModel:
         self.path = path
         if path is None:
             return
-        if path.suffix.lower() == '.onnx' and ort is not None:
+        if path.suffix.lower() == '.onnx':
+            if ort is None:
+                # ONNX models require onnxruntime to run
+                self.kind = 'none'
+                return
             try:
                 providers = (
                     ['CUDAExecutionProvider', 'CPUExecutionProvider']
@@ -50,7 +54,7 @@ class StemModel:
                 return
             except Exception:
                 self.session = None
-                self.kind = 'file'
+                self.kind = 'none'
         else:
             try:
                 self.net = torch.jit.load(str(path), map_location=device)

--- a/stemrunner/server.py
+++ b/stemrunner/server.py
@@ -150,16 +150,16 @@ async def upload_file(
 
     # Ensure required models are present for the requested stems
     manager = ModelManager()
+    missing_all = manager.missing_models()
     missing = []
     for s in stem_list:
         info = manager.model_info.get(s)
         if not info:
             continue
-        model_obj = getattr(manager, s)
-        if model_obj.kind == 'none':
+        if info[0] in missing_all:
             missing.append(info[0])
         cfg = info[1]
-        if cfg and getattr(manager, f"{s}_config") is None:
+        if cfg and cfg in missing_all:
             missing.append(cfg)
     if missing:
         msg = f"models missing: {', '.join(missing)}"

--- a/stemrunner/server.py
+++ b/stemrunner/server.py
@@ -39,7 +39,9 @@ tasks = {}
 controls = {}
 
 process_queue: queue.Queue[callable] = queue.Queue()
-def _worker():
+
+
+def _worker() -> None:
     while True:
         fn = process_queue.get()
         try:
@@ -47,16 +49,6 @@ def _worker():
         finally:
             process_queue.task_done()
 
-threading.Thread(target=_worker, daemon=True).start()
-
-process_queue: queue.Queue[callable] = queue.Queue()
-def _worker():
-    while True:
-        fn = process_queue.get()
-        try:
-            fn()
-        finally:
-            process_queue.task_done()
 
 threading.Thread(target=_worker, daemon=True).start()
 

--- a/stemrunner/server.py
+++ b/stemrunner/server.py
@@ -156,6 +156,23 @@ async def upload_file(
     if not config_path.exists():
         return JSONResponse({'detail': 'config file not found'}, status_code=400)
 
+    # Ensure required models are present for the requested stems
+    manager = ModelManager()
+    missing = []
+    for s in stem_list:
+        info = manager.model_info.get(s)
+        if not info:
+            continue
+        model_obj = getattr(manager, s)
+        if model_obj.kind == 'none':
+            missing.append(info[0])
+        cfg = info[1]
+        if cfg and getattr(manager, f"{s}_config") is None:
+            missing.append(cfg)
+    if missing:
+        msg = f"models missing: {', '.join(missing)}"
+        return JSONResponse({'detail': msg}, status_code=400)
+
     def cb(stage: str, pct: int):
         while pause_evt.is_set():
             progress[task_id] = {'stage': 'paused', 'pct': pct}
@@ -188,7 +205,6 @@ async def upload_file(
                 waveform = torchaudio.functional.resample(waveform, sr, 44100)
                 sr = 44100
 
-            manager = ModelManager()
             out_dir.mkdir(parents=True, exist_ok=True)
             temp_dir = Path(tempfile.gettempdir())
             stems_out: list[str] = []


### PR DESCRIPTION
## Summary
- validate that required models exist before starting a stem separation job
- reuse the loaded ModelManager in the processing thread

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5c41ec9883289a676b453c30667a