### PR TITLE
Add configurable output folder, metadata embedding, and UI hardening

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ beartype>=0.17
 librosa
 imageio-ffmpeg
 certifi
+mutagen

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ beartype>=0.17
 librosa
 imageio-ffmpeg
 certifi
-mutagen

--- a/web/index.html
+++ b/web/index.html
@@ -327,7 +327,7 @@
           body: JSON.stringify(settingsState),
         });
         if(!res.ok){
-          if(showMissingPopup) showPopup('folder doesn\\'t exist');
+          if(showMissingPopup) showPopup("folder doesn't exist");
           await loadSettings();
           return;
         }
@@ -337,7 +337,7 @@
         applySettingsUI();
       }catch(err){
         console.warn('settings update failed', err);
-        if(showMissingPopup) showPopup('folder doesn\\'t exist');
+        if(showMissingPopup) showPopup("folder doesn't exist");
         await loadSettings();
       }
     }

--- a/web/index.html
+++ b/web/index.html
@@ -164,7 +164,7 @@
         <p class="text-sm text-[var(--txt-main)] mt-0">stems</p>
         <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="vocals-box" type="checkbox" class="pretty" checked>vocals</label>
         <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="inst-box" type="checkbox" class="pretty">instrumental</label>
-        <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="deux-box" type="checkbox" class="pretty">both</label>
+        <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="deux-box" type="checkbox" class="pretty">both (deux model)</label>
       </div>
       <button id="start-btn" class="glass-light pre-hide w-64 px-6 py-4 rounded-3xl flex flex-col items-center justify-center fade-in focus:outline-none focus:ring-2 focus:ring-white/30 text-white disabled:opacity-50 disabled:cursor-not-allowed">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-7 h-7 micro" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -829,8 +829,8 @@
         const commitOutput = () => {
           const val = (outputInput.value || '').trim();
           if(!val){
-            outputInput.value = defaultOutputPath;
-            persistSettings({ output_root: defaultOutputPath });
+            outputInput.value = defaultOutputPath || (settingsState.output_root || '');
+            persistSettings({ output_root: outputInput.value });
           }else{
             persistSettings({ output_root: val });
           }

--- a/web/index.html
+++ b/web/index.html
@@ -1344,7 +1344,7 @@
           </div>
           <div class="flex gap-4 text-sm">
             <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="structure-check" type="checkbox" class="pretty">folder structure</label>
-            <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="structureless-check" type="checkbox" class="pretty">structureless (zip)</label>
+            <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="structureless-check" type="checkbox" class="pretty" checked>structureless (zip)</label>
           </div>
         </div>
 
@@ -1367,12 +1367,14 @@
               <li>Software: Stemsplat</li>
               <li>SoftwareVersion: app version</li>
               <li>Model: model file</li>
-              <li class="mt-2">- Debug metadata -</li>
-              <li>Chunks</li>
-              <li>Overlap</li>
-              <li>TimetoProcess</li>
-              <li>ProcessedDate</li>
             </ul>
+            <div class="mt-3 text-xs space-y-1">
+              <div class="font-semibold">Debug metadata</div>
+              <div>Chunks</div>
+              <div>Overlap</div>
+              <div>TimetoProcess</div>
+              <div>ProcessedDate</div>
+            </div>
           </details>
         </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -198,13 +198,12 @@
         </div>
         <div class="bar"><div class="bar-fill progress"></div></div>
       </div>
-      <a class="dl-pad self-center" href="#" title="download">
+      <button class="dl-pad self-center" type="button" title="open folder">
         <svg viewBox="0 0 24 24" class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M12 3v9"/>
-          <path d="M8 10l4 4 4-4"/>
-          <path d="M4 16h16v3a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-3z"/>
+          <path d="M3 7h5l2 3h11v9H3z"/>
+          <path d="M3 7v12"/>
         </svg>
-      </a>
+      </button>
       <a class="stop-pad self-center" href="#" title="stop" style="display:none;">
         <!-- square icon -->
         <svg viewBox="0 0 24 24" class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -231,14 +230,24 @@
     const spacer    = document.getElementById('queue-spacer');
     const closeBtn  = document.getElementById('close-app');
     const startBtn  = document.getElementById('start-btn');
+    const outputInput = document.getElementById('output-path');
+    const outputChoose = document.getElementById('output-choose');
+    const structureCheck = document.getElementById('structure-check');
+    const structurelessCheck = document.getElementById('structureless-check');
+    const metadataCheck = document.getElementById('metadata-check');
+    const debugMetadataCheck = document.getElementById('debug-metadata-check');
+    const metadataDetails = document.getElementById('metadata-details');
 
     let startPressed = false;
     let startGeneration = 0;
+    let startLock = false;
+    let settingsState = { output_root: '', structure_mode: 'structured', metadata_enabled: true, debug_metadata: false };
+    let defaultOutputPath = '';
     updateStartButton();
     function updateStartButton(){
       if(!startBtn) return;
       const hasItems = queue.children.length > 0;
-      if(!hasItems){
+      if(!hasItems || startLock){
         startBtn.disabled = true;
         const icon = startBtn.querySelector('svg');
         if(icon){ icon.style.animation = 'none'; }
@@ -276,6 +285,61 @@
         }
         setTimeout(closeWindow, 220);
       });
+    }
+
+    function applySettingsUI(){
+      if(outputInput && settingsState.output_root){
+        outputInput.value = settingsState.output_root;
+        defaultOutputPath = defaultOutputPath || settingsState.output_root;
+      }
+      if(structureCheck && structurelessCheck){
+        const structured = settingsState.structure_mode !== 'flat';
+        structureCheck.checked = structured;
+        structurelessCheck.checked = !structured;
+      }
+      if(metadataCheck){
+        metadataCheck.checked = !!settingsState.metadata_enabled;
+      }
+      if(debugMetadataCheck){
+        debugMetadataCheck.checked = !!settingsState.debug_metadata;
+      }
+    }
+
+    async function loadSettings(){
+      try{
+        const res = await fetch('/settings');
+        if(!res.ok) return;
+        const data = await res.json();
+        settingsState = { ...settingsState, ...data };
+        defaultOutputPath = data.output_root || defaultOutputPath;
+        applySettingsUI();
+      }catch(err){
+        console.warn('failed to load settings', err);
+      }
+    }
+
+    async function persistSettings(patch, {showMissingPopup = true} = {}){
+      settingsState = { ...settingsState, ...patch };
+      try{
+        const res = await fetch('/settings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(settingsState),
+        });
+        if(!res.ok){
+          if(showMissingPopup) showPopup('folder doesn\\'t exist');
+          await loadSettings();
+          return;
+        }
+        const data = await res.json();
+        settingsState = { ...settingsState, ...data };
+        defaultOutputPath = defaultOutputPath || data.output_root;
+        applySettingsUI();
+      }catch(err){
+        console.warn('settings update failed', err);
+        if(showMissingPopup) showPopup('folder doesn\\'t exist');
+        await loadSettings();
+      }
     }
 
     // settings overlay refs (assigned on load)
@@ -460,6 +524,25 @@
       }
     }
 
+    function bindFolderButton(btn, taskRef){
+      if(!btn || !taskRef) return;
+      btn.onclick = async (e) => {
+        e.preventDefault();
+        if(btn.dataset.busy === '1') return;
+        btn.dataset.busy = '1';
+        try{
+          const res = await fetch('/reveal/' + taskRef.id, { method: 'POST' });
+          if(!res.ok){
+            const msg = taskRef.out_dir ? `folder missing: ${taskRef.out_dir}` : 'output not ready';
+            showPopup(msg);
+          }
+        }catch(err){
+          showPopup('output not ready');
+        }
+        setTimeout(() => { btn.dataset.busy = ''; }, 250);
+      };
+    }
+
     // --- Helper to set rerun and stop icons ---
     
     function setRerunIcon(stopPad){
@@ -540,7 +623,13 @@
         setStopSquareIcon(stopPad);
         stopPad.style.pointerEvents = '';
         stopPad.style.opacity = '';
-        stopPad.onclick = (e) => { e.preventDefault(); fetch('/stop/'+task.id,{method:'POST'}); };
+        stopPad.onclick = async (e) => {
+          if(stopPad.dataset.busy === '1') return;
+          stopPad.dataset.busy = '1';
+          e.preventDefault();
+          try{ await fetch('/stop/'+task.id,{method:'POST'}); }catch(_){ }
+          setTimeout(() => { stopPad.dataset.busy = ''; }, 250);
+        };
         setStopVisibility(stopPad, 'preparing');
       }
       task.stage = 'preparing';
@@ -572,8 +661,9 @@
       smooth.setImmediate(initOverall);
       if(task.pct >= 100){
         st.classList.add('hidden');
-        dl.href = '/download/' + task.id;
         dl.classList.add('show');
+        dl.title = 'open folder';
+        bindFolderButton(dl, task);
         card.classList.add('done');
         if(stopPad) stopPad.remove();
       }
@@ -643,6 +733,8 @@
     }
 
     clearBtn.addEventListener('click', () => {
+      const hasRunning = Array.isArray(tasks) && tasks.some(t => isProcessing(t));
+      if(hasRunning && !confirm('A process is still running. Clear all anyway?')) return;
       if (!startPressed) {
         return withPageFade(() => {
           for (const el of Array.from(queue.children)) { el.remove(); }
@@ -725,6 +817,63 @@
           showPopup('all tasks cleared');
         }catch(err){ showError('force clear failed'); }
       });
+      loadSettings();
+      if(outputInput){
+        const commitOutput = () => {
+          const val = (outputInput.value || '').trim();
+          if(!val){
+            outputInput.value = defaultOutputPath;
+            persistSettings({ output_root: defaultOutputPath });
+          }else{
+            persistSettings({ output_root: val });
+          }
+          outputInput.readOnly = true;
+        };
+        outputInput.addEventListener('focus', () => { outputInput.readOnly = false; outputInput.select(); });
+        outputInput.addEventListener('click', () => { outputInput.readOnly = false; outputInput.select(); });
+        outputInput.addEventListener('blur', commitOutput);
+        outputInput.addEventListener('keydown', (e) => { if(e.key === 'Enter'){ e.preventDefault(); commitOutput(); outputInput.blur(); } });
+      }
+      if(outputChoose){
+        outputChoose.addEventListener('click', async () => {
+          const suggestion = settingsState.output_root || defaultOutputPath;
+          let nextPath = suggestion;
+          try{
+            const manual = prompt('choose folder path', suggestion);
+            if(manual === null) return;
+            nextPath = (manual || '').trim() || suggestion;
+          }catch(err){
+            console.warn('folder prompt failed', err);
+            nextPath = suggestion;
+          }
+          await persistSettings({ output_root: nextPath });
+          applySettingsUI();
+        });
+      }
+      if(structureCheck){
+        structureCheck.addEventListener('change', () => {
+          if(!structureCheck.checked){ structureCheck.checked = true; return; }
+          structurelessCheck.checked = false;
+          persistSettings({ structure_mode: 'structured' });
+        });
+      }
+      if(structurelessCheck){
+        structurelessCheck.addEventListener('change', () => {
+          if(!structurelessCheck.checked){ structurelessCheck.checked = true; return; }
+          structureCheck.checked = false;
+          persistSettings({ structure_mode: 'flat' });
+        });
+      }
+      if(metadataCheck){
+        metadataCheck.addEventListener('change', () => {
+          persistSettings({ metadata_enabled: metadataCheck.checked });
+        });
+      }
+      if(debugMetadataCheck){
+        debugMetadataCheck.addEventListener('change', () => {
+          persistSettings({ debug_metadata: debugMetadataCheck.checked });
+        });
+      }
     });
 
     // drag-and-drop highlights
@@ -862,7 +1011,7 @@
         pendingItems.push(pending);
         newPending.push(pending);
         // persist placeholder task (no id yet)
-        tasks.push({ id:null, name:file.name, pct:0, stage:'ready', stems:[], file:null, tempKey });
+        tasks.push({ id:null, name:file.name, pct:0, stage:'ready', stems:[], file:null, tempKey, out_dir:null });
         saveTasks();
         updateUI();
       });
@@ -928,7 +1077,7 @@
           ui.item.__taskId = parsed.task_id;
           // replace placeholder task
           const idx = tasks.findIndex(t => t.tempKey === pending.tempKey);
-          const t = { id:parsed.task_id, name:file.name, pct:0, stage:'ready', stems:parsed.stems, tempKey: pending.tempKey };
+          const t = { id:parsed.task_id, name:file.name, pct:0, stage:'ready', stems:parsed.stems, tempKey: pending.tempKey, out_dir: null };
           if(idx>=0) tasks[idx]=t; else tasks.push(t);
           saveTasks(); updateUI();
           // enable stop now that we have an id
@@ -938,6 +1087,8 @@
             stopPad.style.opacity = '';
             stopPad.title = 'stop';
             stopPad.onclick = async (e) => {
+              if(stopPad.dataset.busy === '1') return;
+              stopPad.dataset.busy = '1';
               e.preventDefault();
               try{ await fetch('/stop/'+parsed.task_id,{method:'POST'}); }catch(_){ /* ignore */ }
               // mark as stopped locally so UI updates right away
@@ -956,6 +1107,7 @@
                 setRerunIcon(stopPad);
                 stopPad.onclick = (ev) => { ev.preventDefault(); rerunTask(t, { bar, st, dl, stopPad, smooth }); };
               }
+              stopPad.dataset.busy = '';
               updateUI();
             };
             setStopVisibility(stopPad, 'ready');
@@ -984,26 +1136,33 @@
     }
 
     async function startSequentialProcessing(){
-      if(startBtn && startBtn.disabled) return;
-      const stems = selectedStems();
-      if(stems.length === 0){ showPopup('please select at least one stem'); return; }
-      startGeneration += 1;
-      startPressed = true;
-      const batch = pendingItems.slice();
-      batch.forEach(p => { p.autoStart = true; });
-      revealStatusesAfterStart();
-      for(const p of batch){
-        if(!p.uploadPromise){
-          await uploadWithStems(p, stems);
+      if(startLock || (startBtn && startBtn.disabled)) return;
+      startLock = true;
+      updateStartButton();
+      try{
+        const stems = selectedStems();
+        if(stems.length === 0){ showPopup('please select at least one stem'); return; }
+        startGeneration += 1;
+        startPressed = true;
+        const batch = pendingItems.slice();
+        batch.forEach(p => { p.autoStart = true; });
+        revealStatusesAfterStart();
+        for(const p of batch){
+          if(!p.uploadPromise){
+            await uploadWithStems(p, stems);
+          }
+          if(p.uploadPromise){
+            await p.uploadPromise;
+          }
+          startTaskWhenReady(p);
         }
-        if(p.uploadPromise){
-          await p.uploadPromise;
-        }
-        startTaskWhenReady(p);
+        startPressed = false;
+        batch.forEach(p => { p.autoStart = false; });
+        updateUI();
+      } finally {
+        startLock = false;
+        updateStartButton();
       }
-      startPressed = false;
-      batch.forEach(p => { p.autoStart = false; });
-      updateUI();
     }
     if(startBtn) startBtn.addEventListener('click', startSequentialProcessing);
 
@@ -1034,11 +1193,25 @@
           try { data = JSON.parse(ev.data); } catch(_) {}
           if(!data) return;
           const {stage, pct} = data;
-          if(taskRef){ taskRef.stage = stage; taskRef.pct = pct; saveTasks(); }
+          if(taskRef){
+            taskRef.stage = stage;
+            taskRef.pct = pct;
+            if(data.stems) taskRef.stems = data.stems;
+            if(data.out_dir) taskRef.out_dir = data.out_dir;
+            saveTasks();
+          }
+          if(data.stems && st){
+            const parentRow = st.closest('.item-row');
+            applyLabels(parentRow ? parentRow.querySelector('.labels') : null, data.stems);
+          }
           if(stage === 'done'){
             smooth.setTarget(100);
             st.classList.add('hidden');
-            if(dl){ dl.href = '/download/' + taskId; dl.classList.add('show'); }
+            if(dl){
+              dl.classList.add('show');
+              dl.title = 'open folder';
+              bindFolderButton(dl, taskRef || { id: taskId, out_dir: data.out_dir });
+            }
             if(stopPad) stopPad.remove();
             const parent = st.closest('.card'); if(parent) parent.classList.add('done');
             dropPendingById(taskId);
@@ -1075,7 +1248,17 @@
           setStatusVisibility(st, stage);
           setStopVisibility(stopPad, stage);
         });
-        es.addEventListener('error', () => {
+        es.addEventListener('error', (ev) => {
+          let errPayload = null;
+          let errCode = null;
+          let errMsg = null;
+          try{
+            if(ev && ev.data){ errPayload = JSON.parse(ev.data); }
+          }catch(_){}
+          if(errPayload){
+            errCode = errPayload.code || (errPayload.detail && errPayload.detail.code);
+            errMsg = errPayload.message || (errPayload.detail && errPayload.detail.message);
+          }
           if (taskRef) {
             taskRef.stage = 'error';
             taskRef.pct = -1;
@@ -1102,6 +1285,11 @@
           }
           dropPendingById(taskId);
           es.close();
+          if(errCode === 'E004'){
+            showModelsPopup();
+          }else if(errMsg){
+            showPopup(errMsg);
+          }
           updateUI();
         });
               }catch(e){
@@ -1121,16 +1309,58 @@
          class="glass w-11/12 max-w-md p-6 rounded-2xl text-[var(--txt-main)] relative opacity-0"
          style="backdrop-filter: blur(8px) saturate(110%); -webkit-backdrop-filter: blur(8px) saturate(110%); background: rgba(23,35,41,0.45);">
       <button id="settings-close" title="close" class="absolute top-3 right-3 p-2 rounded hover:bg-white/10">✕</button>
-      <h2 class="text-2xl font-light mb-1 select-none">stemsplat</h2>
-      <div class="opacity-80 mb-4">settings</div>
+      <h2 class="text-2xl font-light mb-3 select-none">settings</h2>
 
       <div class="flex flex-col gap-3">
-        <button id="force-clear" class="btn bg-white text-black px-1 py-2 text-xs" style="border-radius:12px;">force clear</button>
-        <div class="text-xs opacity-60">Stops all processing, removes all items, and clears uploaded files.</div>
-      </div>
-      <div class="flex gap-3 mt-3">
-        <a href="https://github.com/Skytheredhead/stemsplat" target="_blank" rel="noopener noreferrer" class="btn bg-white text-black px-1 py-2 text-xs flex-1 text-center" style="border-radius:12px;">github</a>
-        <a href="https://forms.gle/wSpe2nyFgcmuxSr28" target="_blank" rel="noopener noreferrer" class="btn bg-white text-black px-1 py-2 text-xs flex-1 text-center" style="border-radius:12px;">bugs/feedback</a>
+        <div class="space-y-2">
+          <div class="text-sm opacity-80">output folder</div>
+          <div class="flex items-center gap-2">
+            <input id="output-path" type="text" class="w-full px-3 py-2 rounded-lg bg-white/10 border border-white/10 text-sm text-white focus:outline-none focus:ring-2 focus:ring-white/40" readonly value="">
+            <button id="output-choose" class="p-2 rounded-lg hover:bg-white/10 border border-white/10" title="choose folder">
+              <svg viewBox="0 0 24 24" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3 7h5l2 3h11v9H3z"/>
+                <path d="M3 7v12"/>
+              </svg>
+            </button>
+          </div>
+          <div class="flex gap-4 text-sm">
+            <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="structure-check" type="checkbox" class="pretty">folder structure</label>
+            <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="structureless-check" type="checkbox" class="pretty">structureless</label>
+          </div>
+        </div>
+
+        <div class="space-y-2">
+          <div class="flex items-center gap-2">
+            <input id="metadata-check" type="checkbox" class="pretty" checked>
+            <span>embed metadata</span>
+          </div>
+          <details id="metadata-details" class="ml-6 glass-light rounded-lg px-3 py-2 text-xs text-[var(--txt-main)]/90">
+            <summary class="cursor-pointer select-none">included</summary>
+            <ul class="list-disc ml-4 mt-2 space-y-1">
+              <li>Software: Stemsplat</li>
+              <li>SoftwareVersion: app version</li>
+              <li>Model: model file</li>
+            </ul>
+          </details>
+          <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="debug-metadata-check" type="checkbox" class="pretty">debug metadata</label>
+          <div class="ml-6 text-xs opacity-70 space-y-1">
+            <div>Chunks</div>
+            <div>Overlap</div>
+            <div>TimetoProcess</div>
+            <div>ProcessedDate</div>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-3">
+          <button id="force-clear" class="btn bg-white text-black px-1 py-2 text-xs" style="border-radius:12px;">force clear</button>
+          <div class="text-xs opacity-60">Stops all processing, removes all items, and clears uploaded files.</div>
+        </div>
+        <div class="flex gap-3 mt-3">
+          <a href="https://github.com/Skytheredhead/stemsplat" target="_blank" rel="noopener noreferrer" class="btn bg-white text-black px-1 py-2 text-xs flex-1 text-center" style="border-radius:12px;">github</a>
+          <a href="https://forms.gle/wSpe2nyFgcmuxSr28" target="_blank" rel="noopener noreferrer" class="btn bg-white text-black px-1 py-2 text-xs flex-1 text-center" style="border-radius:12px;">bugs/feedback</a>
+          <a href="https://huggingface.co/becruily" target="_blank" rel="noopener noreferrer" class="btn bg-white text-black px-1 py-2 text-xs flex-1 text-center" style="border-radius:12px;">becruily models</a>
+        </div>
+        <div class="text-xs opacity-70 text-center">models by becruily</div>
       </div>
 
       <div class="mt-6 text-center opacity-70 text-sm">v0.1</div>

--- a/web/index.html
+++ b/web/index.html
@@ -235,13 +235,11 @@
     const structureCheck = document.getElementById('structure-check');
     const structurelessCheck = document.getElementById('structureless-check');
     const metadataCheck = document.getElementById('metadata-check');
-    const debugMetadataCheck = document.getElementById('debug-metadata-check');
-    const metadataDetails = document.getElementById('metadata-details');
 
     let startPressed = false;
     let startGeneration = 0;
     let startLock = false;
-    let settingsState = { output_root: '', structure_mode: 'flat', metadata_enabled: true, debug_metadata: false };
+    let settingsState = { output_root: '', structure_mode: 'flat' };
     let defaultOutputPath = '';
     updateStartButton();
     function updateStartButton(){
@@ -298,10 +296,7 @@
           structurelessCheck.checked = !structured;
       }
       if(metadataCheck){
-        metadataCheck.checked = !!settingsState.metadata_enabled;
-      }
-      if(debugMetadataCheck){
-        debugMetadataCheck.checked = !!settingsState.debug_metadata;
+        metadataCheck.checked = true;
       }
     }
 
@@ -1353,28 +1348,15 @@
         <div class="space-y-3">
           <div class="flex items-center gap-4">
             <label class="flex items-center gap-2 text-[var(--txt-main)]">
-              <input id="metadata-check" type="checkbox" class="pretty" checked>
-              <span>embed metadata</span>
-            </label>
-            <label class="flex items-center gap-2 text-[var(--txt-main)]">
-              <input id="debug-metadata-check" type="checkbox" class="pretty">
-              <span>debug metadata</span>
+              <input id="metadata-check" type="checkbox" class="pretty" checked disabled>
+              <span>embed model info</span>
             </label>
           </div>
           <details id="metadata-details" class="ml-2 glass-light rounded-lg px-3 py-2 text-xs text-[var(--txt-main)]/90">
             <summary class="cursor-pointer select-none">example</summary>
             <ul class="list-disc ml-4 mt-2 space-y-1">
-              <li>Software: Stemsplat</li>
-              <li>SoftwareVersion: app version</li>
               <li>Model: model file</li>
             </ul>
-            <div class="mt-3 text-xs space-y-1">
-              <div class="font-semibold">Debug metadata</div>
-              <div>Chunks</div>
-              <div>Overlap</div>
-              <div>TimetoProcess</div>
-              <div>ProcessedDate</div>
-            </div>
           </details>
         </div>
 

--- a/web/index.html
+++ b/web/index.html
@@ -241,7 +241,7 @@
     let startPressed = false;
     let startGeneration = 0;
     let startLock = false;
-    let settingsState = { output_root: '', structure_mode: 'structured', metadata_enabled: true, debug_metadata: false };
+    let settingsState = { output_root: '', structure_mode: 'flat', metadata_enabled: true, debug_metadata: false };
     let defaultOutputPath = '';
     updateStartButton();
     function updateStartButton(){
@@ -293,9 +293,9 @@
         defaultOutputPath = defaultOutputPath || settingsState.output_root;
       }
       if(structureCheck && structurelessCheck){
-        const structured = settingsState.structure_mode !== 'flat';
-        structureCheck.checked = structured;
-        structurelessCheck.checked = !structured;
+          const structured = settingsState.structure_mode === 'structured';
+          structureCheck.checked = structured;
+          structurelessCheck.checked = !structured;
       }
       if(metadataCheck){
         metadataCheck.checked = !!settingsState.metadata_enabled;
@@ -659,7 +659,7 @@
       const smooth = makeProgressSmoother(bar);
       const initOverall = Math.max(0, Math.min(100, task.pct || 0));
       smooth.setImmediate(initOverall);
-      if(task.pct >= 100){
+      if(task.stage === 'done'){
         st.classList.add('hidden');
         dl.classList.add('show');
         dl.title = 'open folder';
@@ -698,6 +698,13 @@
         st.textContent = task.stage ? `${displayStage(task.stage)} (${sp}%)` : 'queued';
         smooth.setImmediate(sp);
         setStopVisibility(stopPad, task.stage);
+      }
+      if(task.stage !== 'done' && dl && !isProcessing(task)){
+        dl.classList.add('show');
+        dl.title = 'retry';
+        dl.innerHTML = '';
+        setRerunIcon(dl);
+        dl.onclick = (e) => { e.preventDefault(); rerunTask(task, { bar, st, dl, stopPad, smooth }); };
       }
       setStatusVisibility(st, task.stage);
       const inserted = node.children[0];
@@ -926,7 +933,16 @@
       setTimeout(() => card.remove(), 3000);
     }
 
-    function showModelsPopup(onCancel){
+    async function showModelsPopup(onCancel){
+      try{
+        const res = await fetch('/models_status');
+        if(res.ok){
+          const data = await res.json();
+          if(Array.isArray(data.missing) && data.missing.length === 0){
+            return;
+          }
+        }
+      }catch(_){}
       const declined = localStorage.getItem('declinedModels');
       const msg = declined ? "you didn't put the models in :(" : 'models not found! would you like me to download them?';
       const yes = declined ? 'download' : 'yes please';
@@ -1242,6 +1258,9 @@
             } else {
               smooth.setTarget(sp);
             }
+            if(stage !== 'done' && dl){
+              dl.classList.remove('show');
+            }
           } else {
             st.textContent = 'queued';
           }
@@ -1313,7 +1332,7 @@
 
       <div class="flex flex-col gap-3">
         <div class="space-y-2">
-          <div class="text-sm opacity-80">output folder</div>
+          <div class="text-sm opacity-80">output folder (leave blank for Downloads folder)</div>
           <div class="flex items-center gap-2">
             <input id="output-path" type="text" class="w-full px-3 py-2 rounded-lg bg-white/10 border border-white/10 text-sm text-white focus:outline-none focus:ring-2 focus:ring-white/40" readonly value="">
             <button id="output-choose" class="p-2 rounded-lg hover:bg-white/10 border border-white/10" title="choose folder">
@@ -1325,42 +1344,51 @@
           </div>
           <div class="flex gap-4 text-sm">
             <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="structure-check" type="checkbox" class="pretty">folder structure</label>
-            <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="structureless-check" type="checkbox" class="pretty">structureless</label>
+            <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="structureless-check" type="checkbox" class="pretty">structureless (zip)</label>
           </div>
         </div>
 
-        <div class="space-y-2">
-          <div class="flex items-center gap-2">
-            <input id="metadata-check" type="checkbox" class="pretty" checked>
-            <span>embed metadata</span>
+        <div class="border-t border-white/10 my-4"></div>
+
+        <div class="space-y-3">
+          <div class="flex items-center gap-4">
+            <label class="flex items-center gap-2 text-[var(--txt-main)]">
+              <input id="metadata-check" type="checkbox" class="pretty" checked>
+              <span>embed metadata</span>
+            </label>
+            <label class="flex items-center gap-2 text-[var(--txt-main)]">
+              <input id="debug-metadata-check" type="checkbox" class="pretty">
+              <span>debug metadata</span>
+            </label>
           </div>
-          <details id="metadata-details" class="ml-6 glass-light rounded-lg px-3 py-2 text-xs text-[var(--txt-main)]/90">
-            <summary class="cursor-pointer select-none">included</summary>
+          <details id="metadata-details" class="ml-2 glass-light rounded-lg px-3 py-2 text-xs text-[var(--txt-main)]/90">
+            <summary class="cursor-pointer select-none">example</summary>
             <ul class="list-disc ml-4 mt-2 space-y-1">
               <li>Software: Stemsplat</li>
               <li>SoftwareVersion: app version</li>
               <li>Model: model file</li>
+              <li class="mt-2">- Debug metadata -</li>
+              <li>Chunks</li>
+              <li>Overlap</li>
+              <li>TimetoProcess</li>
+              <li>ProcessedDate</li>
             </ul>
           </details>
-          <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="debug-metadata-check" type="checkbox" class="pretty">debug metadata</label>
-          <div class="ml-6 text-xs opacity-70 space-y-1">
-            <div>Chunks</div>
-            <div>Overlap</div>
-            <div>TimetoProcess</div>
-            <div>ProcessedDate</div>
-          </div>
         </div>
+
+        <div class="border-t border-white/10 my-4"></div>
 
         <div class="flex flex-col gap-3">
           <button id="force-clear" class="btn bg-white text-black px-1 py-2 text-xs" style="border-radius:12px;">force clear</button>
           <div class="text-xs opacity-60">Stops all processing, removes all items, and clears uploaded files.</div>
         </div>
+        <div class="border-t border-white/10 my-4"></div>
+
         <div class="flex gap-3 mt-3">
           <a href="https://github.com/Skytheredhead/stemsplat" target="_blank" rel="noopener noreferrer" class="btn bg-white text-black px-1 py-2 text-xs flex-1 text-center" style="border-radius:12px;">github</a>
           <a href="https://forms.gle/wSpe2nyFgcmuxSr28" target="_blank" rel="noopener noreferrer" class="btn bg-white text-black px-1 py-2 text-xs flex-1 text-center" style="border-radius:12px;">bugs/feedback</a>
-          <a href="https://huggingface.co/becruily" target="_blank" rel="noopener noreferrer" class="btn bg-white text-black px-1 py-2 text-xs flex-1 text-center" style="border-radius:12px;">becruily models</a>
         </div>
-        <div class="text-xs opacity-70 text-center">models by becruily</div>
+        <div class="text-xs opacity-70 text-center"><a href="https://huggingface.co/becruily" target="_blank" rel="noopener noreferrer" class="underline">models by becruily</a></div>
       </div>
 
       <div class="mt-6 text-center opacity-70 text-sm">v0.1</div>


### PR DESCRIPTION
### Motivation
- Provide a user-configurable output destination and folder-structure options so generated stems can be saved to predictable locations instead of ad-hoc upload folders.
- Embed provenance metadata into finished stems with an opt-in debug mode to aid reproducibility and diagnostics.
- Replace the per-file download button with an action that opens the folder containing the generated stems, and surface clear warnings and anti-spam guards to make the UI less error-prone.
- Credit the model author and avoid repeated model-download prompts when models are already available.

### Description
- Backend: added `UserSettings` and helpers (`DEFAULT_OUTPUT_ROOT`, `resolve_output_dir_for_task`, `ensure_unique_path`, `ensure_unique_dir`) plus endpoints `GET /settings`, `POST /settings`, and `POST /reveal/{task_id}` to persist settings and reveal output folders, and updated `_queue_processing`/`/start`/`/rerun` to resolve and store output dirs and include `stems`/`out_dir` in progress payloads.
- Metadata & naming: added optional WAV metadata embedding using `mutagen` (`_apply_metadata`) and made file/zip names unique using `ensure_unique_path` (saves as `name`, `name_2`, etc.) and `ensure_unique_dir` for structure collisions.
- Frontend: updated `web/index.html` settings overlay to show `output folder` text input + folder chooser button, `folder structure` / `structureless` checkboxes, `embed metadata` and `debug metadata` toggles (with included metadata details), a credit/link to `https://huggingface.co/becruily`, and changed finished-item control to a folder-open button wired to `/reveal/{task_id}`.
- UI hardening: added anti-spam locks for `start` (`startLock`) and per-button `dataset.busy` guards on stop/reveal actions, a confirm prompt if `clear all` is clicked while processing, model-missing handling that triggers the model download popup only on a model-missing error (`E004`), and client-side application of stem-type labels from SSE progress payloads.
- Misc: added `mutagen` to `requirements.txt` and introduced `APP_VERSION` constant used in metadata.

### Testing
- Compiled the modified server module with `python -m compileall main.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c99a2a50083289407e0ba15c412f2)