### PR TITLE
Stop running tasks and reset state when clearing uploads

### DIFF
--- a/install.py
+++ b/install.py
@@ -141,7 +141,7 @@ def run_server():
     try:
         with socketserver.TCPServer(("localhost", PORT), handler) as httpd:
             logger.info("installer ui listening on http://localhost:%s", PORT)
-            webbrowser.open(f"http://localhost:{PORT}/")
+            webbrowser.open(f"http://localhost:{PORT}/", new=0)
             server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
             server_thread.start()
             logger.debug("waiting for installer routine to finish before shutting ui")
@@ -153,7 +153,7 @@ def run_server():
                 httpd.server_close()
                 server_thread.join(timeout=2)
                 try:
-                    webbrowser.open(f"http://localhost:{MAIN_PORT}/")
+                    webbrowser.open(f"http://localhost:{MAIN_PORT}/", new=0)
                 except Exception:
                     logger.debug("failed to open browser after installer shutdown", exc_info=True)
             except KeyboardInterrupt:
@@ -219,7 +219,7 @@ def _start_server():
     if not _port_available(MAIN_PORT):
         logger.info("main server already running on port %s; opening browser", MAIN_PORT)
         try:
-            webbrowser.open(f"http://localhost:{MAIN_PORT}/")
+            webbrowser.open(f"http://localhost:{MAIN_PORT}/", new=0)
         except Exception:
             logger.debug("failed to open browser for existing server", exc_info=True)
         shutdown_event.set()
@@ -228,7 +228,7 @@ def _start_server():
         [str(python_path()), "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", str(MAIN_PORT)]
     )
     try:
-        webbrowser.open(f"http://localhost:{MAIN_PORT}/")
+        webbrowser.open(f"http://localhost:{MAIN_PORT}/", new=0)
     except Exception:
         logger.debug("failed to open browser after starting server", exc_info=True)
 

--- a/install.py
+++ b/install.py
@@ -152,6 +152,10 @@ def run_server():
                 httpd.shutdown()
                 httpd.server_close()
                 server_thread.join(timeout=2)
+                try:
+                    webbrowser.open(f"http://localhost:{MAIN_PORT}/")
+                except Exception:
+                    logger.debug("failed to open browser after installer shutdown", exc_info=True)
             except KeyboardInterrupt:
                 logger.info("installer interrupted; shutting down")
                 httpd.shutdown()
@@ -213,14 +217,20 @@ def _models_missing():
 def _start_server():
     logger.info("starting main server with uvicorn on port %s", MAIN_PORT)
     if not _port_available(MAIN_PORT):
-        msg = f"Port {MAIN_PORT} is already in use. Please close the other process or change MAIN_PORT."
-        logger.error(msg)
-        print(msg)
+        logger.info("main server already running on port %s; opening browser", MAIN_PORT)
+        try:
+            webbrowser.open(f"http://localhost:{MAIN_PORT}/")
+        except Exception:
+            logger.debug("failed to open browser for existing server", exc_info=True)
         shutdown_event.set()
         return
     subprocess.Popen(
         [str(python_path()), "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", str(MAIN_PORT)]
     )
+    try:
+        webbrowser.open(f"http://localhost:{MAIN_PORT}/")
+    except Exception:
+        logger.debug("failed to open browser after starting server", exc_info=True)
 
 
 def _download_models(selection: Optional[list[str]] = None):

--- a/install.py
+++ b/install.py
@@ -152,10 +152,7 @@ def run_server():
                 httpd.shutdown()
                 httpd.server_close()
                 server_thread.join(timeout=2)
-                try:
-                    webbrowser.open(f"http://localhost:{MAIN_PORT}/", new=0)
-                except Exception:
-                    logger.debug("failed to open browser after installer shutdown", exc_info=True)
+                logger.debug("installer ui closed; main app launch handled by installer page")
             except KeyboardInterrupt:
                 logger.info("installer interrupted; shutting down")
                 httpd.shutdown()
@@ -218,19 +215,13 @@ def _start_server():
     logger.info("starting main server with uvicorn on port %s", MAIN_PORT)
     if not _port_available(MAIN_PORT):
         logger.info("main server already running on port %s; opening browser", MAIN_PORT)
-        try:
-            webbrowser.open(f"http://localhost:{MAIN_PORT}/", new=0)
-        except Exception:
-            logger.debug("failed to open browser for existing server", exc_info=True)
+        logger.debug("main server already running; installer page will navigate")
         shutdown_event.set()
         return
     subprocess.Popen(
         [str(python_path()), "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", str(MAIN_PORT)]
     )
-    try:
-        webbrowser.open(f"http://localhost:{MAIN_PORT}/", new=0)
-    except Exception:
-        logger.debug("failed to open browser after starting server", exc_info=True)
+    logger.debug("main server started; installer page will navigate")
 
 
 def _download_models(selection: Optional[list[str]] = None):

--- a/main.py
+++ b/main.py
@@ -1601,6 +1601,29 @@ async def download(task_id: str):
 
 @app.post("/clear_all_uploads")
 async def clear_all_uploads():
+    # stop any running tasks
+    for ctrl in controls.values():
+        try:
+            ctrl.get("pause", threading.Event()).set()
+            ctrl.get("stop", threading.Event()).set()
+        except Exception:
+            logger.debug("failed to signal stop for control %s", ctrl, exc_info=True)
+
+    # drain any queued items so they don't start after clearing
+    try:
+        while True:
+            fn = process_queue.get_nowait()
+            process_queue.task_done()
+            logger.debug("discarded queued task %s during clear_all_uploads", fn)
+    except queue.Empty:
+        pass
+
+    # reset in-memory state
+    progress.clear()
+    tasks.clear()
+    errors.clear()
+    controls.clear()
+
     dirs = [UPLOAD_DIR, CONVERTED_DIR]
     for dir_path in dirs:
         if dir_path.exists():
@@ -1609,7 +1632,7 @@ async def clear_all_uploads():
                     shutil.rmtree(entry)
                 else:
                     entry.unlink()
-    logger.info("cleared upload directories")
+    logger.info("cleared upload directories and reset task state")
     return {"status": "cleared"}
 
 

--- a/main.py
+++ b/main.py
@@ -219,10 +219,8 @@ _ensure_dir(settings.output_root)
 def resolve_output_plan(info: dict, *, structure_mode: Optional[str] = None) -> dict[str, Path | str | None]:
     base_name = Path(info.get("orig_name") or info.get("conv_src", "stems")).stem
     root = DEFAULT_OUTPUT_ROOT
-    _ensure_dir(root)
     flat_root = root.parent if root.name == "stemsplat" else root
-    staging_dir = ensure_unique_dir(flat_root / f"{base_name}—stems")
-    staging_dir.mkdir(parents=True, exist_ok=True)
+    staging_dir = Path(tempfile.mkdtemp(prefix="stemsplat_stage_", dir=str(CONVERTED_DIR)))
     deliver_dir = flat_root
     zip_target = ensure_unique_path(flat_root / f"{base_name}.zip")
     return {"deliver_dir": deliver_dir, "staging_dir": staging_dir, "zip_target": zip_target, "structure_mode": "flat"}

--- a/main.py
+++ b/main.py
@@ -220,6 +220,7 @@ def resolve_output_plan(info: dict, *, structure_mode: Optional[str] = None) -> 
     base_name = Path(info.get("orig_name") or info.get("conv_src", "stems")).stem
     root = DEFAULT_OUTPUT_ROOT
     flat_root = root.parent if root.name == "stemsplat" else root
+    _ensure_dir(flat_root)
     staging_dir = Path(tempfile.mkdtemp(prefix="stemsplat_stage_", dir=str(CONVERTED_DIR)))
     deliver_dir = flat_root
     zip_target = ensure_unique_path(flat_root / f"{base_name}.zip")

--- a/web/index.html
+++ b/web/index.html
@@ -629,8 +629,8 @@
     }
 
     function enforceCapacity(){
-      const total = tasks.filter(Boolean).length;
-      const full = total >= MAX_TASKS;
+      const activeCount = tasks.filter(t => t && !isFinished(t)).length;
+      const full = activeCount >= MAX_TASKS;
       dropzone.classList.toggle('pointer-events-none', full);
       dropzone.classList.toggle('opacity-60', full);
       if(fileInput) fileInput.disabled = full;
@@ -1362,6 +1362,30 @@
       startLock = true;
       updateStartButton();
       let markedStarted = false;
+      const markReadyQueuedUI = () => {
+        const rows = Array.from(queue.children);
+        let changed = false;
+        rows.forEach(row => {
+          const id = row.__taskId;
+          const task = id ? getTaskById(id) : null;
+          if(task && (!task.stage || task.stage === 'ready' || task.stage === 'queued')){
+            if(task.stage !== 'queued' || task.pct !== 0){
+              task.stage = 'queued';
+              task.pct = 0;
+              changed = true;
+            }
+            const chip = row.querySelector('.chip');
+            if(chip){
+              showStatus(chip);
+              chip.textContent = 'queued';
+              chip.classList.remove('hidden');
+            }
+          }
+        });
+        if(changed){
+          saveTasks();
+        }
+      };
       const startReadyTasks = async () => {
         const ready = Array.isArray(tasks)
           ? tasks.filter(t => t && t.id && (!t.stage || t.stage === 'ready' || t.stage === 'queued'))
@@ -1374,6 +1398,7 @@
           }catch(_){}
         }
         saveTasks();
+        markReadyQueuedUI();
       };
       try{
         const stems = selectedStems();
@@ -1381,6 +1406,7 @@
         startGeneration += 1;
         startPressed = true;
         markedStarted = true;
+        markReadyQueuedUI();
         const batch = pendingItems.slice();
         batch.forEach(p => { p.autoStart = true; });
         revealStatusesAfterStart();
@@ -1483,10 +1509,11 @@
           if (typeof pct === 'number' && pct >= 0) {
             const sp = Math.round(Math.max(0, Math.min(100, pct)));
             const friendlyStage = displayStage(stage);
-            st.textContent = friendlyStage ? `${friendlyStage} (${sp}%)` : 'queued';
             if (stage === 'queued' || stage === 'ready') {
+              st.textContent = friendlyStage || 'queued';
               smooth.setImmediate(0);
             } else {
+              st.textContent = friendlyStage ? `${friendlyStage} (${sp}%)` : `${sp}%`;
               smooth.setTarget(sp);
             }
             if(stage !== 'done' && dl){

--- a/web/index.html
+++ b/web/index.html
@@ -1362,6 +1362,19 @@
       startLock = true;
       updateStartButton();
       let markedStarted = false;
+      const startReadyTasks = async () => {
+        const ready = Array.isArray(tasks)
+          ? tasks.filter(t => t && t.id && (!t.stage || t.stage === 'ready' || t.stage === 'queued'))
+          : [];
+        for(const t of ready){
+          try{
+            await fetch('/start/' + t.id, { method:'POST' });
+            t.stage = 'queued';
+            t.pct = 0;
+          }catch(_){}
+        }
+        saveTasks();
+      };
       try{
         const stems = selectedStems();
         if(stems.length === 0){ showPopup('please select at least one stem'); return; }
@@ -1380,6 +1393,7 @@
           }
           startTaskWhenReady(p);
         }
+        await startReadyTasks();
         startPressed = false;
         markedStarted = false;
         batch.forEach(p => { p.autoStart = false; });

--- a/web/index.html
+++ b/web/index.html
@@ -283,7 +283,7 @@
         await Promise.allSettled(tasks);
       };
       const closeWindow = () => {
-        try { window.open('','_self'); window.close(); } catch(_) {}
+        try { window.close(); } catch(_) {}
         window.location.replace('about:blank');
       };
       closeBtn.addEventListener('click', async () => {

--- a/web/index.html
+++ b/web/index.html
@@ -942,6 +942,7 @@
         for (const el of Array.from(queue.children)) { el.remove(); }
         tasks = [];
         pendingItems.length = 0;
+        startLock = false;
         startPressed = false;
         saveTasks();
         try { fetch('/clear_all_uploads', {method:'POST'}); } catch(_){ }
@@ -1402,7 +1403,10 @@
       };
       try{
         const stems = selectedStems();
-        if(stems.length === 0){ showPopup('please select at least one stem'); return; }
+        if(stems.length === 0){
+          showPopup('please select at least one stem');
+          return;
+        }
         startGeneration += 1;
         startPressed = true;
         markedStarted = true;

--- a/web/index.html
+++ b/web/index.html
@@ -290,6 +290,14 @@
         closeBtn.disabled = true;
         closeBtn.style.opacity = '0.7';
         try {
+          if(Array.isArray(tasks)){
+            for(const t of tasks){
+              if(t && t.id){
+                try { fetch('/stop/' + t.id, { method:'POST', keepalive:true }); } catch(_){}
+              }
+            }
+          }
+          try { fetch('/clear_all_uploads', { method:'POST', keepalive:true }); } catch(_){}
           await sendShutdown();
         } catch (err) {
           console.error('shutdown failed', err);
@@ -762,6 +770,53 @@
       sq.appendChild(rect);
       stopPad.appendChild(sq);
     }
+
+    function setDownloadIcon(btn){
+      if(!btn) return;
+      while (btn.firstChild) btn.removeChild(btn.firstChild);
+      const NS = 'http://www.w3.org/2000/svg';
+      const svg = document.createElementNS(NS,'svg');
+      svg.setAttribute('viewBox','0 0 24 24');
+      svg.classList.add('w-7','h-7');
+      svg.setAttribute('fill','none');
+      svg.setAttribute('stroke','#0F2027');
+      svg.setAttribute('stroke-width','2.2');
+      svg.setAttribute('stroke-linecap','round');
+      svg.setAttribute('stroke-linejoin','round');
+      const arr = document.createElementNS(NS,'path');
+      arr.setAttribute('d','M12 5v10m0 0l-4-4m4 4l4-4');
+      const base = document.createElementNS(NS,'path');
+      base.setAttribute('d','M5 19h14');
+      svg.append(arr, base);
+      btn.appendChild(svg);
+    }
+
+    function setFolderIcon(btn){
+      if(!btn) return;
+      while (btn.firstChild) btn.removeChild(btn.firstChild);
+      btn.insertAdjacentHTML('afterbegin', '<svg viewBox="0 0 24 24" class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7h5l2 3h11v9H3z"/><path d="M3 7v12"/></svg>');
+    }
+
+    function bindDownloadButton(btn, taskRef){
+      if(!btn || !taskRef || !taskRef.id) return;
+      btn.classList.add('show');
+      setDownloadIcon(btn);
+      btn.title = 'download';
+      guardClick(btn, (e) => {
+        e.preventDefault();
+        const a = document.createElement('a');
+        a.href = '/download/' + taskRef.id;
+        a.rel = 'noopener';
+        a.download = '';
+        document.body.appendChild(a);
+        a.click();
+        setTimeout(() => { try{ a.remove(); }catch(_){}} , 250);
+        taskRef.downloaded = true;
+        saveTasks();
+        setFolderIcon(btn);
+        bindFolderButton(btn, taskRef);
+      });
+    }
 // --- Helper to rerun a task server-side ---
     async function rerunTask(task, ui){
       const {bar, st, dl, stopPad, smooth} = ui;
@@ -817,6 +872,7 @@
       }
       task.stage = 'preparing';
       task.pct = 0;
+      task.downloaded = false;
       saveTasks();
       updateUI();
       // resume tracking
@@ -1223,7 +1279,7 @@
         pendingItems.push(pending);
         newPending.push(pending);
         // persist placeholder task (no id yet)
-        tasks.push({ id:null, name:file.name, pct:0, stage:'ready', stems:[], file:null, tempKey, out_dir:null });
+        tasks.push({ id:null, name:file.name, pct:0, stage:'ready', stems:[], file:null, tempKey, out_dir:null, downloaded:false });
         saveTasks();
         updateUI();
       }
@@ -1294,7 +1350,7 @@
           ui.item.__taskId = parsed.task_id;
           // replace placeholder task
           const idx = tasks.findIndex(t => t.tempKey === pending.tempKey);
-          const t = { id:parsed.task_id, name:file.name, pct:0, stage:'ready', stems:parsed.stems, tempKey: pending.tempKey, out_dir: null };
+          const t = { id:parsed.task_id, name:file.name, pct:0, stage:'ready', stems:parsed.stems, tempKey: pending.tempKey, out_dir: null, downloaded:false };
           if(idx>=0) tasks[idx]=t; else tasks.push(t);
           saveTasks(); updateUI();
           // enable stop now that we have an id
@@ -1396,6 +1452,7 @@
             await fetch('/start/' + t.id, { method:'POST' });
             t.stage = 'queued';
             t.pct = 0;
+            if(typeof t.downloaded === 'undefined'){ t.downloaded = false; }
           }catch(_){}
         }
         saveTasks();
@@ -1473,6 +1530,7 @@
             if(data.stems) taskRef.stems = data.stems;
             if(data.out_dir) taskRef.out_dir = data.out_dir;
             if(data.zip) taskRef.zip = data.zip;
+            if(typeof taskRef.downloaded === 'undefined'){ taskRef.downloaded = false; }
             saveTasks();
           }
           if(data.stems && st){
@@ -1484,9 +1542,15 @@
             smooth.setTarget(100);
             hideStatus(st);
             if(dl){
-              dl.classList.add('show');
-              dl.title = 'open folder';
-              bindFolderButton(dl, taskRef || { id: taskId, out_dir: data.out_dir });
+              const ref = taskRef || { id: taskId, out_dir: data.out_dir, zip: data.zip, downloaded:false };
+              if(ref.downloaded){
+                setFolderIcon(dl);
+                dl.classList.add('show');
+                dl.title = 'open folder';
+                bindFolderButton(dl, ref);
+              }else{
+                bindDownloadButton(dl, ref);
+              }
             }
             if(stopPad) stopPad.remove();
             const parent = st.closest('.card'); if(parent) parent.classList.add('done');

--- a/web/index.html
+++ b/web/index.html
@@ -931,41 +931,21 @@
         const ok = await showConfirm('A process is still running. Clear all anyway?');
         if(!ok) return;
       }
-      if (!startPressed) {
-        return withPageFade(() => {
-          for (const el of Array.from(queue.children)) { el.remove(); }
-          tasks = [];
-          pendingItems.length = 0;
-          saveTasks();
-          try { fetch('/clear_all_uploads', {method:'POST'}); } catch(_){ }
-          updateUI();
-        });
-      }
-
       withPageFade(() => {
-        const children = Array.from(queue.children);
-        const clearable = new Set(tasks.filter(t => isFinished(t)).map(t => t.id));
-        if(clearable.size === 0){ updateUI(); return; }
-        // fade out only clearable ones
-        children.forEach(el => {
-          const id = el.__taskId || null;
-          if(id && clearable.has(id)){
-            el.classList.add('fade');
-            el.style.opacity = '0';
-          }
-        });
-        setTimeout(() => {
-          // remove DOM + prune tasks
-          for(const el of Array.from(queue.children)){
-            const id = el.__taskId || null;
-            if(id && clearable.has(id)) el.remove();
-          }
-          tasks = tasks.filter(t => !clearable.has(t.id));
-          pendingItems.length = 0;
-          saveTasks();
-          fetch('/clear_all_uploads', {method:'POST'});
-          updateUI();
-        }, 240);
+        if(Array.isArray(tasks)){
+          tasks.forEach(t => {
+            if(t && t.id){
+              try { fetch('/stop/' + t.id, {method:'POST'}); } catch(_){}
+            }
+          });
+        }
+        for (const el of Array.from(queue.children)) { el.remove(); }
+        tasks = [];
+        pendingItems.length = 0;
+        startPressed = false;
+        saveTasks();
+        try { fetch('/clear_all_uploads', {method:'POST'}); } catch(_){ }
+        updateUI();
       });
     });
 
@@ -1381,11 +1361,13 @@
       }
       startLock = true;
       updateStartButton();
+      let markedStarted = false;
       try{
         const stems = selectedStems();
         if(stems.length === 0){ showPopup('please select at least one stem'); return; }
         startGeneration += 1;
         startPressed = true;
+        markedStarted = true;
         const batch = pendingItems.slice();
         batch.forEach(p => { p.autoStart = true; });
         revealStatusesAfterStart();
@@ -1399,9 +1381,13 @@
           startTaskWhenReady(p);
         }
         startPressed = false;
+        markedStarted = false;
         batch.forEach(p => { p.autoStart = false; });
         updateUI();
       } finally {
+        if(markedStarted){
+          startPressed = false;
+        }
         startLock = false;
         updateStartButton();
       }

--- a/web/install.html
+++ b/web/install.html
@@ -9,6 +9,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     :root{ --bg-1:#0F2027; --bg-2:#2C5364; --txt:#E7ECEF; --accent:#8ED8FF; --card:rgba(23,35,41,.55); --border:rgba(255,255,255,.06); }
+    html, body { background-color: #0B1A1F; }
     body{ background: linear-gradient(135deg,#0B1A1F 0%, var(--bg-1) 35%, var(--bg-2) 100%); color:var(--txt); font-family:'Nunito Sans',system-ui,sans-serif; }
     @view-transition { navigation: auto; }
     .noise::before { content: ""; position: fixed; inset: 0; pointer-events: none; background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="3" stitchTiles="stitch"/></filter><rect width="120" height="120" filter="url(%23n)" opacity="0.035"/></svg>') repeat; opacity:.18; }
@@ -139,7 +140,6 @@
       const loading = document.getElementById('loading');
       // start a quick fade-out and cue the intro for the app page
       const shell = document.getElementById('installer-shell');
-      document.body.classList.add('fade-out');
       if(shell){ shell.classList.add('fade-out'); }
       card.style.animation = 'fade .4s ease reverse both';
       loading.classList.remove('hidden');


### PR DESCRIPTION
### Motivation
- Clearing uploads previously only removed on-disk files but left in-memory task state and queued work, causing UI inconsistencies such as an unclickable `start` button and leftover items after `clear all`/`force clear`.
- Running or queued tasks could continue or be rehydrated after a clear which produced stale/invalid UI state.
- The intent is to ensure a full, safe reset of both server-side and client-side state when the user requests a clear so uploads can be resumed cleanly.

### Description
- Updated `clear_all_uploads` in `main.py` to signal `pause`/`stop` for all controls, drain `process_queue` with `get_nowait()`, and clear in-memory maps `progress`, `tasks`, `errors`, and `controls` before removing uploaded files.
- Modified the client `clear` handler in `web/index.html` to always issue `POST /stop/{id}` for known tasks, remove all queue DOM nodes, reset `tasks` and `pendingItems`, clear `startPressed`, and call `POST /clear_all_uploads` to sync server state.
- Made `startSequentialProcessing` more resilient by tracking `markedStarted` so `startPressed` is reliably cleared even if the batch start fails partway through.
- Added debug logging to indicate discarded queued tasks and an updated log message when clearing directories and resetting task state.

### Testing
- No automated tests were executed for these changes.
- Manual stress testing is recommended to confirm behavior when uploading many files, triggering `clear all`, and using `force clear` to verify the UI and server state are fully reset.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d933e8c048328a7f1454539ecb4a8)