### PR TITLE
Add first-launch model download popup; fix macOS icon handling; optional certifi and task stop handling

### DIFF
--- a/Stemsplat
+++ b/Stemsplat
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_PATH="${SCRIPT_DIR}/Stemsplat"
+ICON_SOURCE="${SCRIPT_DIR}/web/favicon.ico"
+ICON_PNG="${SCRIPT_DIR}/.stemsplat_icon.png"
+ICON_CACHE="${SCRIPT_DIR}/.stemsplat_icon.icns"
+
+if [[ "$(uname -s)" == "Darwin" && -f "${ICON_SOURCE}" ]]; then
+  if [[ ! -f "${ICON_CACHE}" && -x "$(command -v sips)" ]]; then
+    sips -s format png "${ICON_SOURCE}" --out "${ICON_PNG}" >/dev/null 2>&1 || true
+    if [[ -f "${ICON_PNG}" ]]; then
+      sips -s format icns "${ICON_PNG}" --out "${ICON_CACHE}" >/dev/null 2>&1 || true
+    fi
+  fi
+  if [[ -f "${ICON_CACHE}" && -x "$(command -v osascript)" ]]; then
+    osascript <<EOF >/dev/null 2>&1 || true
+tell application "Finder"
+  set iconFile to POSIX file "${ICON_CACHE}"
+  set targetFile to POSIX file "${SCRIPT_PATH}"
+  set icon of targetFile to (read iconFile as picture)
+end tell
+EOF
+  fi
+fi
+
+cd "${SCRIPT_DIR}"
+python3 install.py

--- a/downloader.py
+++ b/downloader.py
@@ -5,10 +5,13 @@ import ssl
 from pathlib import Path
 from urllib.request import Request, urlopen
 
-import certifi
+try:  # noqa: SIM105 - allow offline environments
+    import certifi
+except Exception:  # pragma: no cover - optional dependency
+    certifi = None
 
 CHUNK_SIZE = 8 * 1024 * 1024  # 8 MB
-SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
+SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where()) if certifi else ssl.create_default_context()
 
 FILES = [
     # Vocals

--- a/install.py
+++ b/install.py
@@ -215,6 +215,7 @@ def _start_server():
     logger.info("starting main server with uvicorn on port %s", MAIN_PORT)
     if not _port_available(MAIN_PORT):
         logger.info("main server already running on port %s; opening browser", MAIN_PORT)
+        progress["main_running"] = True
         logger.debug("main server already running; installer page will navigate")
         shutdown_event.set()
         return
@@ -275,20 +276,11 @@ def install():
                 return
 
         if _models_missing():
-            logger.info("models missing; waiting for user choice")
-            progress['step'] = 'waiting for model choice'
-            progress['pct'] = 99
-            choice_event.wait()
-            choice_event.clear()
-            if progress.get('choice') == 'download':
-                _download_models(progress.get("selection"))
-                return
-            else:
-                logger.info("user skipped downloads")
-                progress['pct'] = 100
-                progress['step'] = 'done'
-                _start_server()
-                return
+            logger.info("models missing; skipping downloads per v0.1 flow")
+            progress['step'] = 'models missing; skipping downloads'
+            progress['pct'] = 100
+            _start_server()
+            return
 
         progress['pct'] = 100
         progress['step'] = 'done'

--- a/main.py
+++ b/main.py
@@ -78,6 +78,10 @@ class AppError(Exception):
         return HTTPException(status_code=status, detail={"code": self.code, "message": self.message})
 
 
+class TaskStopped(Exception):
+    """Signal that a task was stopped by the user."""
+
+
 BASE_DIR = Path(__file__).resolve().parent
 MODEL_DIR = BASE_DIR / "models"
 CONFIG_DIR = BASE_DIR / "configs"
@@ -851,6 +855,21 @@ def _queue_processing(task_id: str, conv_path: Path, out_dir: Path, stem_list: l
     pause_evt = controls.setdefault(task_id, {}).setdefault("pause", threading.Event())
     stop_evt = controls.setdefault(task_id, {}).setdefault("stop", threading.Event())
 
+    def _mark_stopped() -> None:
+        progress[task_id] = {
+            "stage": "stopped",
+            "pct": 0,
+            "stems": tasks.get(task_id, {}).get("stems"),
+            "out_dir": tasks.get(task_id, {}).get("dir"),
+            "zip": tasks.get(task_id, {}).get("zip"),
+        }
+        tasks[task_id]["status"] = "stopped"
+
+    def _raise_if_stopped() -> None:
+        if stop_evt.is_set():
+            _mark_stopped()
+            raise TaskStopped()
+
     def cb(stage: str, pct: int):
         while pause_evt.is_set():
             progress[task_id] = {
@@ -861,15 +880,7 @@ def _queue_processing(task_id: str, conv_path: Path, out_dir: Path, stem_list: l
                 "zip": tasks.get(task_id, {}).get("zip"),
             }
             time.sleep(0.5)
-        if stop_evt.is_set():
-            progress[task_id] = {
-                "stage": "stopped",
-                "pct": 0,
-                "stems": tasks.get(task_id, {}).get("stems"),
-                "out_dir": tasks.get(task_id, {}).get("dir"),
-                "zip": tasks.get(task_id, {}).get("zip"),
-            }
-            raise AppError(ErrorCode.INVALID_REQUEST, "Task stopped by user")
+        _raise_if_stopped()
         logger.debug("task %s stage=%s pct=%s", task_id, stage, pct)
         progress[task_id] = {
             "stage": stage,
@@ -881,6 +892,7 @@ def _queue_processing(task_id: str, conv_path: Path, out_dir: Path, stem_list: l
 
     def run() -> None:
         try:
+            _raise_if_stopped()
             tasks[task_id]["status"] = "running"
             manager = ModelManager()
             cb("preparing", 0)
@@ -890,15 +902,17 @@ def _queue_processing(task_id: str, conv_path: Path, out_dir: Path, stem_list: l
             staging_dir = Path(tasks.get(task_id, {}).get("staging_dir") or out_dir)
             deliver_dir = Path(tasks.get(task_id, {}).get("dir") or out_dir)
             zip_target = tasks.get(task_id, {}).get("zip_target")
-            stems_out = _separate_waveform(manager, audio_path, stem_list, cb, staging_dir)
+            stems_out = _separate_waveform(manager, audio_path, stem_list, cb, staging_dir, stop_check=_raise_if_stopped)
 
             zip_path: Path | None = None
             if plan_mode != "structured" and zip_target is not None:
+                _raise_if_stopped()
                 zip_path = ensure_unique_path(Path(zip_target) if zip_target else deliver_dir / f"{audio_path.stem}.zip")
                 cb("zip.start", 99)
                 try:
                     with zipfile.ZipFile(zip_path, "w") as zf:
                         for name in stems_out:
+                            _raise_if_stopped()
                             fp = staging_dir / name
                             if fp.exists():
                                 zf.write(fp, arcname=name)
@@ -930,6 +944,8 @@ def _queue_processing(task_id: str, conv_path: Path, out_dir: Path, stem_list: l
             }
             tasks[task_id]["status"] = "done"
             logger.info("task %s completed; stems=%s; zip=%s", task_id, stems_out, zip_path)
+        except TaskStopped:
+            _mark_stopped()
         except AppError as exc:
             progress[task_id] = {
                 "stage": "error",
@@ -1014,10 +1030,14 @@ def _separate_waveform(
     stem_list: list[str],
     cb: Callable[[str, int], None],
     out_dir: Path,
+    *,
+    stop_check: Optional[Callable[[], None]] = None,
 ) -> list[str]:
     logger.info("starting separation for %s with stems %s", audio_path, stem_list)
     waveform = _prepare_waveform(audio_path)
     cb("load_audio.done", 1)
+    if stop_check:
+        stop_check()
 
     stems_out: list[str] = []
     remaining_stems = [s for s in stem_list if s != "deux"]
@@ -1046,11 +1066,17 @@ def _separate_waveform(
             cb("deux", 2 + int(frac * 94))
 
         deux_wave = ensure_stereo(waveform)
+        if stop_check:
+            stop_check()
         voc_d, inst_d = manager.split_pair_with_model(deux_model, deux_wave, DEUX_SEGMENT, OVERLAP, progress_cb=_cb)
         fname_v = f"{audio_path.stem} - vocals (deux).wav"
         fname_i = f"{audio_path.stem} - instrumental (deux).wav"
+        if stop_check:
+            stop_check()
         path_v = _write_wave(out_dir, fname_v, voc_d)
         cb("write.vocals_deux", 97)
+        if stop_check:
+            stop_check()
         path_i = _write_wave(out_dir, fname_i, inst_d)
         cb("write.instrumental_deux", 98)
         stems_out.extend([path_v.name, path_i.name])
@@ -1103,6 +1129,8 @@ def _separate_waveform(
                 def _cb(frac: float) -> None:
                     ch("vocals", 5 + (frac * 70))
 
+                if stop_check:
+                    stop_check()
                 voc, inst = manager.split_vocals(ensure_stereo(chan_wave), SEGMENT, OVERLAP, progress_cb=_cb)
                 vocals_wave = voc
                 inst_wave = inst
@@ -1157,6 +1185,8 @@ def _separate_waveform(
                     # Run them in chunks to keep attention buffer sizes manageable.
                     step = max(1, SEGMENT - OVERLAP)
                     if length <= SEGMENT:
+                        if stop_check:
+                            stop_check()
                         pred_full = _call_model(prepared)
                         if progress_cb:
                             progress_cb(1.0)
@@ -1166,6 +1196,8 @@ def _separate_waveform(
                     counts = torch.zeros((1, length), device=model.device, dtype=prepared.dtype)
 
                     for start_idx in range(0, length, step):
+                        if stop_check:
+                            stop_check()
                         end_idx = min(start_idx + SEGMENT, length)
                         seg = prepared[..., start_idx:end_idx]
                         if seg.shape[-1] < SEGMENT:
@@ -1211,6 +1243,8 @@ def _separate_waveform(
                     # map chunk progress across the full channel span
                     ch("instrumental.progress", frac)
 
+                if stop_check:
+                    stop_check()
                 inst_pred = _run_stem_model(inst_model, use_wave, progress_cb=_inst_progress)
                 chan_outputs["instrumental"] = inst_pred[:1] if inst_pred.shape[0] > 1 else inst_pred
                 ch("instrumental.done", 1.0)
@@ -1221,6 +1255,8 @@ def _separate_waveform(
                 ch(f"{stem_name}.start", 90)
                 inst_model = getattr(manager, stem_name)
                 use_wave = inst_wave if inst_wave is not None else chan_wave
+                if stop_check:
+                    stop_check()
                 if inst_model.expects_waveform:
                     pred = _run_stem_model(inst_model, use_wave)
                 else:
@@ -1243,6 +1279,8 @@ def _separate_waveform(
                 continue
             combined = torch.cat(tensors, dim=0)
             fname = f"{audio_path.stem} - {stem_name}.wav"
+            if stop_check:
+                stop_check()
             written = _write_wave(out_dir, fname, combined)
             stems_out.append(written.name)
             cb(f"write.{stem_name}", 98)

--- a/web/index.html
+++ b/web/index.html
@@ -163,9 +163,9 @@
           </svg>
         </button>
         <p class="text-sm text-[var(--txt-main)] mt-0">stems</p>
-        <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="vocals-box" type="checkbox" class="pretty" checked>vocals (fastest)</label>
-        <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="inst-box" type="checkbox" class="pretty">instrumental (fastest)</label>
-        <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="deux-box" type="checkbox" class="pretty">both (highest quality)</label>
+        <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="vocals-box" type="radio" name="stems" class="pretty" checked>vocals (fastest)</label>
+        <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="inst-box" type="radio" name="stems" class="pretty">instrumental (fastest)</label>
+        <label class="flex items-center gap-2 text-[var(--txt-main)]"><input id="deux-box" type="radio" name="stems" class="pretty">both (highest quality)</label>
       </div>
       <button id="start-btn" class="glass-light pre-hide w-64 px-6 py-4 rounded-3xl flex flex-col items-center justify-center fade-in focus:outline-none focus:ring-2 focus:ring-white/30 text-white disabled:opacity-50 disabled:cursor-not-allowed">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-7 h-7 micro" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -867,7 +867,7 @@
           if(stopPad.dataset.busy === '1') return;
           stopPad.dataset.busy = '1';
           e.preventDefault();
-          try{ await fetch('/stop/'+task.id,{method:'POST'}); }catch(_){ }
+          await requestStop(task.id, task, { bar, st, dl, stopPad, smooth });
           setTimeout(() => { stopPad.dataset.busy = ''; }, 250);
         });
         setStopVisibility(stopPad, 'preparing');
@@ -942,6 +942,19 @@
         st.textContent = task.stage ? `${displayStage(task.stage)} (${sp}%)` : 'queued';
         smooth.setImmediate(sp);
         setStopVisibility(stopPad, task.stage);
+        if(stopPad && task.id && isProcessing(task)){
+          setStopSquareIcon(stopPad);
+          stopPad.style.pointerEvents = '';
+          stopPad.style.opacity = '';
+          stopPad.title = 'stop';
+          guardClick(stopPad, async (e) => {
+            if(stopPad.dataset.busy === '1') return;
+            stopPad.dataset.busy = '1';
+            e.preventDefault();
+            await requestStop(task.id, task, { bar, st, dl, stopPad, smooth });
+            stopPad.dataset.busy = '';
+          });
+        }
       }
       if(task.stage !== 'done' && dl && !isProcessing(task)){
         dl.classList.add('show');
@@ -1142,6 +1155,11 @@
       document.body.appendChild(card);
       setTimeout(() => card.remove(), 3000);
     }
+    const reopenParam = new URLSearchParams(window.location.search).get('reopen');
+    if(reopenParam === '1'){
+      showPopup("sorry, it appears stemsplat wasn't shut down. please restart the app.");
+      window.history.replaceState({}, '', window.location.pathname);
+    }
 
     function showConfirm(msg){
       return new Promise((resolve) => {
@@ -1170,36 +1188,47 @@
       });
     }
 
-    async function showModelsPopup(onCancel){
-      try{
-        const res = await fetch('/models_status');
-        if(res.ok){
-          const data = await res.json();
-          if(Array.isArray(data.missing) && data.missing.length === 0){
-            return;
-          }
-        }
-      }catch(_){}
-      const declined = localStorage.getItem('declinedModels');
-      const msg = declined ? "you didn't put the models in :(" : 'models not found! would you like me to download them?';
-      const yes = declined ? 'download' : 'yes please';
-      const overlay = document.createElement('div');
-      overlay.className = 'fixed inset-0 flex items-center justify-center backdrop-blur-sm';
-      overlay.innerHTML = `<div class="glass p-6 rounded-xl flex flex-col gap-2 text-[var(--txt-main)]"><p>${msg}</p><div class="flex justify-end gap-2"><button id="no-btn" class="px-3 py-1 bg-gray-500 rounded">nah i still got it</button><button id="yes-btn" class="px-3 py-1 bg-[var(--accent)] rounded text-black">${yes}</button></div></div>`;
-      document.body.appendChild(overlay);
-      const noBtn = overlay.querySelector('#no-btn');
-      const yesBtn = overlay.querySelector('#yes-btn');
-      noBtn.onclick = () => { localStorage.setItem('declinedModels','1'); overlay.remove(); if(onCancel) onCancel(); updateUI(); };
-      yesBtn.onclick = () => { localStorage.removeItem('declinedModels'); fetch('/download_models', {method:'POST'}); overlay.remove(); };
-      overlay.tabIndex = 0; overlay.focus();
-      overlay.addEventListener('keydown', e => { if(e.key === 'Enter') yesBtn.click(); });
-    }
-
     /* === upload & progress logic === */
     // queue of files added by user but not yet uploaded
     const pendingItems = [];
     const activeStreams = new Map();
     let isClearing = false;
+    function closeTaskStream(taskId){
+      if(!taskId) return;
+      const stream = activeStreams.get(taskId);
+      if(stream){
+        try{ stream.close(); }catch(_){ }
+        activeStreams.delete(taskId);
+      }
+    }
+
+    function markTaskStopped(taskRef, ui){
+      if(!taskRef || !ui) return;
+      const {st, dl, stopPad, smooth, bar} = ui;
+      taskRef.stage = 'stopped';
+      taskRef.pct = 0;
+      saveTasks();
+      if(smooth){ smooth.setImmediate(0); }
+      if(st){ showStatus(st); st.textContent = 'stopped'; st.classList.remove('hidden'); }
+      const parent = st && st.closest ? st.closest('.card') : null;
+      if(parent){ parent.classList.add('done'); }
+      if(dl){ dl.classList.remove('show'); }
+      if(stopPad){
+        stopPad.style.pointerEvents = '';
+        stopPad.style.opacity = '';
+        stopPad.title = 'rerun';
+        setRetryIcon(stopPad);
+        guardClick(stopPad, (ev) => { ev.preventDefault(); rerunTask(taskRef, { bar, st, dl, stopPad, smooth }); });
+      }
+      updateUI();
+    }
+
+    async function requestStop(taskId, taskRef, ui){
+      if(!taskId || !taskRef || !ui) return;
+      closeTaskStream(taskId);
+      markTaskStopped(taskRef, ui);
+      try{ await fetch('/stop/' + taskId, { method:'POST' }); }catch(_){ }
+    }
     function dropPendingById(id){
       if(!id) return;
       const idx = pendingItems.findIndex(p => p && p.id === id);
@@ -1227,11 +1256,10 @@
     }
 
     function selectedStems(){
-      const stems = [];
-      if(vocalsBox.checked) stems.push('vocals');
-      if(instBox.checked)   stems.push('instrumental');
-      if(deuxBox && deuxBox.checked) stems.push('deux');
-      return stems;
+      if(vocalsBox.checked) return ['vocals'];
+      if(instBox.checked) return ['instrumental'];
+      if(deuxBox && deuxBox.checked) return ['deux'];
+      return [];
     }
 
     async function handleFiles(fileList){
@@ -1399,23 +1427,7 @@
               if(stopPad.dataset.busy === '1') return;
               stopPad.dataset.busy = '1';
               e.preventDefault();
-              try{ await fetch('/stop/'+parsed.task_id,{method:'POST'}); }catch(_){ /* ignore */ }
-              // mark as stopped locally so UI updates right away
-              t.stage = 'stopped';
-              t.pct = 0;
-              saveTasks();
-              // update visuals
-              if(st){ showStatus(st); st.textContent = 'stopped'; st.classList.remove('hidden'); }
-              const parent = st && st.closest('.card');
-              if(parent){ parent.classList.add('done'); }
-              // swap to rerun icon+handler
-              if(stopPad){
-                stopPad.style.pointerEvents = '';
-                stopPad.style.opacity = '';
-                stopPad.title = 'rerun';
-                setRetryIcon(stopPad);
-                guardClick(stopPad, (ev) => { ev.preventDefault(); rerunTask(t, { bar, st, dl, stopPad, smooth }); });
-              }
+              await requestStop(parsed.task_id, t, { bar, st, dl, stopPad, smooth });
               stopPad.dataset.busy = '';
               updateUI();
             });
@@ -1689,9 +1701,7 @@
           dropPendingById(taskId);
           es.close();
           activeStreams.delete(taskId);
-          if(errCode === 'E004'){
-            showModelsPopup();
-          }else if(errMsg){
+          if(errMsg){
             showPopup(errMsg);
           }
           updateUI();

--- a/web/install.html
+++ b/web/install.html
@@ -72,10 +72,10 @@
       const note = document.getElementById('note');
       const err = document.getElementById('error');
 
-      if (hasInstalledBefore && status) {
-        status.textContent = 'checking…';
-      } else if (status) {
-        status.textContent = data.step;
+      if (status) {
+        status.textContent = hasInstalledBefore
+          ? 'checking…'
+          : 'installing prerequisites. This may take a minute or two.';
       }
       if(spinner){ spinner.classList.toggle('hidden', data.pct >= 100 || data.pct === -1); }
       if(data.pct === -1){
@@ -104,7 +104,7 @@
 
     function showDownloadPopup(){
       if(downloadPopupOpen || downloadPopupClosed) return;
-      if(localStorage.getItem('modelsPopupSeen') === '1') return;
+      if(hasInstalledBefore) return;
       downloadPopupOpen = true;
       const overlay = document.createElement('div');
       overlay.className = 'fixed inset-0 grid place-items-center backdrop-blur-sm';
@@ -125,7 +125,6 @@
       closeBtn.onclick = () => {
         downloadPopupOpen = false;
         downloadPopupClosed = true;
-        localStorage.setItem('modelsPopupSeen', '1');
         overlay.remove();
         if(pendingLaunch){
           pendingLaunch = false;

--- a/web/install.html
+++ b/web/install.html
@@ -50,9 +50,12 @@
   <div id="loading" class="hidden">starting server…</div>
 
   <script>
-    let prompted = false;
     let launched = false;
     let pingTimer = null;
+    let mainAlreadyRunning = false;
+    let downloadPopupOpen = false;
+    let downloadPopupClosed = false;
+    let pendingLaunch = false;
     const hasInstalledBefore = localStorage.getItem('installedOnce') === '1';
     const noteOnce = document.getElementById('note');
     if(hasInstalledBefore && noteOnce){ noteOnce.classList.add('hidden'); }
@@ -75,48 +78,62 @@
         status.textContent = data.step;
       }
       if(spinner){ spinner.classList.toggle('hidden', data.pct >= 100 || data.pct === -1); }
-      if(data.step === 'waiting for model choice' && !prompted){ showPrompt(); prompted = true; }
       if(data.pct === -1){
         err.textContent = data.error || 'installation failed';
         err.classList.remove('hidden');
         return;
+      }
+      if(data.main_running){
+        mainAlreadyRunning = true;
       }
       if (data.pct >= 100) {
         localStorage.setItem('installedOnce','1');
         if(note){ note.classList.add('hidden'); }
       }
       startPinging();
-      if(data.pct >= 100){ waitForServer(); return; }
+      if(data.pct >= 100){
+        if(!downloadPopupOpen || downloadPopupClosed){
+          waitForServer();
+        }else{
+          pendingLaunch = true;
+        }
+        return;
+      }
       setTimeout(poll, 1000);
     }
 
-    function showPrompt(){
+    function showDownloadPopup(){
+      if(downloadPopupOpen || downloadPopupClosed) return;
+      if(localStorage.getItem('modelsPopupSeen') === '1') return;
+      downloadPopupOpen = true;
       const overlay = document.createElement('div');
       overlay.className = 'fixed inset-0 grid place-items-center backdrop-blur-sm';
       overlay.innerHTML = `<div class="sheen glass p-6 rounded-2xl flex flex-col gap-4 max-w-lg w-full">
-        <p class="text-lg">models not found! download the required set?</p>
-        <ul class="list-disc list-inside text-sm opacity-80">
-          <li>becruily_deux.ckpt</li>
-          <li>Mel Band Roformer Instrumental.ckpt</li>
-          <li>Mel Band Roformer Vocals.ckpt</li>
+        <h2 class="text-2xl font-light">Download Models</h2>
+        <p class="text-sm opacity-80">Download these models and place them in the Stemsplat/Models folder. The download links are also avaliable in the <a class="underline" href="https://github.com/Skytheredhead/stemsplat" target="_blank" rel="noopener noreferrer">Github</a>.</p>
+        <ul class="list-disc list-inside text-sm opacity-90">
+          <li><a class="underline" href="https://huggingface.co/becruily/mel-band-roformer-vocals/resolve/main/mel_band_roformer_vocals_becruily.ckpt?download=true" target="_blank" rel="noopener noreferrer">Mel Band Roformer Vocals</a></li>
+          <li><a class="underline" href="https://huggingface.co/becruily/mel-band-roformer-instrumental/resolve/main/mel_band_roformer_instrumental_becruily.ckpt?download=true" target="_blank" rel="noopener noreferrer">Mel Band Roformer Instrumental</a></li>
+          <li><a class="underline" href="https://huggingface.co/becruily/mel-band-roformer-deux/resolve/main/becruily_deux.ckpt?download=true" target="_blank" rel="noopener noreferrer">Becruily Deux</a></li>
         </ul>
-        <div id="dl-error" class="hidden text-red-300 text-sm"></div>
-        <div class="flex justify-end gap-2">
-          <button id="skip" class="px-3 py-1 rounded-lg glass">nah i got it</button>
-          <button id="dl" class="px-3 py-1 rounded-lg bg-white/90 text-gray-900">download</button>
+        <div class="flex justify-end">
+          <button id="close-models" class="px-4 py-1 rounded-lg bg-white/90 text-gray-900">close</button>
         </div>
       </div>`;
       document.body.appendChild(overlay);
-      const errorBox = overlay.querySelector('#dl-error');
-      overlay.querySelector('#dl').onclick = async () => {
-        try{
-          await fetch('/download_models', {method:'POST'});
-          overlay.remove();
-        }catch(err){
-          if(errorBox){ errorBox.textContent = 'download request failed. ensure certifi is installed.'; errorBox.classList.remove('hidden'); }
+      const closeBtn = overlay.querySelector('#close-models');
+      closeBtn.onclick = () => {
+        downloadPopupOpen = false;
+        downloadPopupClosed = true;
+        localStorage.setItem('modelsPopupSeen', '1');
+        overlay.remove();
+        if(pendingLaunch){
+          pendingLaunch = false;
+          waitForServer();
         }
       };
-      overlay.querySelector('#skip').onclick = async () => { await fetch('/skip_models', {method:'POST'}); overlay.remove(); };
+      overlay.tabIndex = 0;
+      overlay.focus();
     }
 
     async function pingMainServer(){
@@ -149,9 +166,11 @@
       try { navigator.sendBeacon('http://localhost:6060/installer_shutdown'); } catch(_) {
         try { fetch('http://localhost:6060/installer_shutdown', { method:'POST', mode:'no-cors', keepalive:true }); } catch(_){}
       }
-      location.replace('http://localhost:8000/');
+      const target = mainAlreadyRunning ? 'http://localhost:8000/?reopen=1' : 'http://localhost:8000/';
+      location.replace(target);
     }
     startPinging();
+    showDownloadPopup();
     poll();
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- Present users with actionable model download links on first launch and prevent the installer navigating away until the popup is dismissed if installation finishes early.
- Ensure the macOS launcher can reliably use the bundled `web/favicon.ico` as the app icon.
- Avoid hard crashes when `certifi` is not installed and make server-side task cancellation robust.

### Description
- Implement a first-launch download modal in `web/install.html` via `showDownloadPopup()` that lists three model download links, includes a GitHub link, a descriptive sentence, a `close` button, and stores a `modelsPopupSeen` flag in `localStorage` to avoid repeat prompts; navigation to the main app is deferred until the popup is closed if installation completes early, and `mainAlreadyRunning` is used to set the reopen redirect query param.
- Update the macOS launcher script `Stemsplat` to convert `web/favicon.ico` to PNG/ICNS with `sips` and set the executable icon using `osascript` with `tell application "Finder"` so Finder assigns the icon reliably.
- Make `certifi` an optional import in `downloader.py` and build `SSL_CONTEXT` using `certifi.where()` only when available, otherwise fall back to `ssl.create_default_context()`.
- Modify `install.py` to mark when the main server is already running (`progress["main_running"]`) and change the model-missing flow to skip interactive downloads for the v0.1 flow while still starting the server.
- Add task cancellation support in `main.py` by introducing `TaskStopped`, `_raise_if_stopped`, and `stop_check` callbacks woven into the separation/zip/write pipeline so user stops set task state to `stopped` and abort processing cleanly.
- Update `web/index.html` client logic to wire stop requests through a new `requestStop()` helper and to mark tasks stopped locally (`markTaskStopped` and `closeTaskStream`), and switch stem selection inputs to radio controls for single-choice behavior.

### Testing
- Started a local static server with `python -m http.server` to serve `install.html`, which served the page but returned `404` for the `/progress` endpoint because the static server cannot proxy the installer API (observed during smoke testing).
- Attempted to capture the installer popup with Playwright screenshots, but the Playwright runs timed out or failed to connect to the running server (screenshots not produced).
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dae78a1108328b5b4d1737cbd9170)