### PR TITLE
Update installer text and first-run model popup behavior

### DIFF
--- a/install.py
+++ b/install.py
@@ -243,7 +243,7 @@ def _download_models(selection: Optional[list[str]] = None):
 def install():
     logger.info("install routine starting")
     try:
-        progress['step'] = 'checking installation'
+        progress['step'] = 'installing prerequisites'
         progress['pct'] = 1
         if _installed():
             logger.info("virtual environment already present")

--- a/web/install.html
+++ b/web/install.html
@@ -90,7 +90,8 @@
         localStorage.setItem('installedOnce','1');
         if(note){ note.classList.add('hidden'); }
       }
-      if (data.pct < 100 && data.pct !== -1) {
+      const missingModels = Array.isArray(data.models_missing) ? data.models_missing : [];
+      if (missingModels.length > 0) {
         showDownloadPopup();
       }
       startPinging();

--- a/web/install.html
+++ b/web/install.html
@@ -73,9 +73,9 @@
       const err = document.getElementById('error');
 
       if (status) {
-        status.textContent = hasInstalledBefore
-          ? 'checking…'
-          : 'installing prerequisites. This may take a minute or two.';
+        status.textContent = data.pct < 100 && data.pct !== -1
+          ? 'installing prerequisites. This may take a minute or two.'
+          : 'checking…';
       }
       if(spinner){ spinner.classList.toggle('hidden', data.pct >= 100 || data.pct === -1); }
       if(data.pct === -1){
@@ -89,6 +89,9 @@
       if (data.pct >= 100) {
         localStorage.setItem('installedOnce','1');
         if(note){ note.classList.add('hidden'); }
+      }
+      if (data.pct < 100 && data.pct !== -1) {
+        showDownloadPopup();
       }
       startPinging();
       if(data.pct >= 100){
@@ -104,13 +107,12 @@
 
     function showDownloadPopup(){
       if(downloadPopupOpen || downloadPopupClosed) return;
-      if(hasInstalledBefore) return;
       downloadPopupOpen = true;
       const overlay = document.createElement('div');
       overlay.className = 'fixed inset-0 grid place-items-center backdrop-blur-sm';
       overlay.innerHTML = `<div class="sheen glass p-6 rounded-2xl flex flex-col gap-4 max-w-lg w-full">
         <h2 class="text-2xl font-light">Download Models</h2>
-        <p class="text-sm opacity-80">Download these models and place them in the Stemsplat/Models folder. The download links are also avaliable in the <a class="underline" href="https://github.com/Skytheredhead/stemsplat" target="_blank" rel="noopener noreferrer">Github</a>.</p>
+        <p class="text-sm opacity-80">Download these models and place them in the Stemsplat/Models folder. The download links are also available in the <a class="underline" href="https://github.com/Skytheredhead/stemsplat" target="_blank" rel="noopener noreferrer">Github</a>.</p>
         <ul class="list-disc list-inside text-sm opacity-90">
           <li><a class="underline" href="https://huggingface.co/becruily/mel-band-roformer-vocals/resolve/main/mel_band_roformer_vocals_becruily.ckpt?download=true" target="_blank" rel="noopener noreferrer">Mel Band Roformer Vocals</a></li>
           <li><a class="underline" href="https://huggingface.co/becruily/mel-band-roformer-instrumental/resolve/main/mel_band_roformer_instrumental_becruily.ckpt?download=true" target="_blank" rel="noopener noreferrer">Mel Band Roformer Instrumental</a></li>
@@ -169,7 +171,6 @@
       location.replace(target);
     }
     startPinging();
-    showDownloadPopup();
     poll();
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- Make the installer messaging and first-run model download UX match the expected flow so users see "installing prerequisites…" during active installs and get a models download popup they can act on while install runs.

### Description
- Change the initial installer progress step text in `install.py` from `checking installation` to `installing prerequisites` so backend progress and UI text align.
- Update `web/install.html` so the status line shows the "installing prerequisites" copy while `data.pct < 100`, and switch to "checking…" otherwise.
- Trigger the models download popup while installation is in progress (`data.pct < 100`), remove the previous guard that suppressed the popup on first run, and stop showing the popup unconditionally on load so it is driven by progress state instead.
- Fix popup copy typo (`avaliable` -> `available`) and keep the GitHub/model links and a close button in the popup; if the install finishes before the user closes the popup the page will wait and only navigate after the popup is closed.

### Testing
- Served the `web` folder on `http://127.0.0.1:8001` and ran an automated Playwright script to load `/install.html`, wait for the `Download Models` popup text, and capture a screenshot; the Playwright check and screenshot succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f508d9f483288c07a8b04060539b)